### PR TITLE
Codebase formatting

### DIFF
--- a/src/complex.rs
+++ b/src/complex.rs
@@ -4,26 +4,20 @@ use crate::{
 };
 use rug::{ops::Pow, Complex};
 #[derive(Clone)]
-pub enum NumStr
-{
+pub enum NumStr {
     Num(Complex),
     Str(String),
     Vector(Vec<Complex>),
     Matrix(Vec<Vec<Complex>>),
 }
-impl NumStr
-{
-    pub fn mul(&self, b: &Self) -> Result<Self, &'static str>
-    {
-        Ok(match (self, b)
-        {
+impl NumStr {
+    pub fn mul(&self, b: &Self) -> Result<Self, &'static str> {
+        Ok(match (self, b) {
             (Num(a), Num(b)) => Num(a * b.clone()),
-            (Num(b), Vector(a)) | (Vector(a), Num(b)) =>
-            {
+            (Num(b), Vector(a)) | (Vector(a), Num(b)) => {
                 Vector(a.iter().map(|a| a * b.clone()).collect())
             }
-            (Vector(a), Vector(b)) if a.len() == b.len() =>
-            {
+            (Vector(a), Vector(b)) if a.len() == b.len() => {
                 Vector(a.iter().zip(b.iter()).map(|(a, b)| a * b.clone()).collect())
             }
             (Num(b), Matrix(a)) | (Matrix(a), Num(b)) => Matrix(
@@ -56,15 +50,12 @@ impl NumStr
             _ => return Err("mul err"),
         })
     }
-    pub fn div(&self, b: &Self) -> Result<Self, &'static str>
-    {
-        Ok(match (self, b)
-        {
+    pub fn div(&self, b: &Self) -> Result<Self, &'static str> {
+        Ok(match (self, b) {
             (Num(a), Num(b)) => Num(a / b.clone()),
             (Num(a), Vector(b)) => Vector(b.iter().map(|b| a / b.clone()).collect()),
             (Vector(a), Num(b)) => Vector(a.iter().map(|a| a / b.clone()).collect()),
-            (Vector(a), Vector(b)) if a.len() == b.len() =>
-            {
+            (Vector(a), Vector(b)) if a.len() == b.len() => {
                 Vector(a.iter().zip(b.iter()).map(|(a, b)| a / b.clone()).collect())
             }
             (Num(a), Matrix(b)) => Matrix(
@@ -99,10 +90,8 @@ impl NumStr
             _ => return Err("div err"),
         })
     }
-    pub fn pm(&self, b: &Self) -> Result<Self, &'static str>
-    {
-        Ok(match (self, b)
-        {
+    pub fn pm(&self, b: &Self) -> Result<Self, &'static str> {
+        Ok(match (self, b) {
             (Num(a), Num(b)) => Vector(vec![a + b.clone(), a - b.clone()]),
             (Num(a), Vector(b)) | (Vector(b), Num(a)) => Matrix(vec![
                 b.iter().map(|b| a + b.clone()).collect(),
@@ -115,17 +104,13 @@ impl NumStr
             _ => return Err("plus-minus unsupported"),
         })
     }
-    pub fn add(&self, b: &Self) -> Result<Self, &'static str>
-    {
-        Ok(match (self, b)
-        {
+    pub fn add(&self, b: &Self) -> Result<Self, &'static str> {
+        Ok(match (self, b) {
             (Num(a), Num(b)) => Num(a + b.clone()),
-            (Num(a), Vector(b)) | (Vector(b), Num(a)) =>
-            {
+            (Num(a), Vector(b)) | (Vector(b), Num(a)) => {
                 Vector(b.iter().map(|b| a + b.clone()).collect())
             }
-            (Vector(a), Vector(b)) if a.len() == b.len() =>
-            {
+            (Vector(a), Vector(b)) if a.len() == b.len() => {
                 Vector(a.iter().zip(b.iter()).map(|(a, b)| a + b.clone()).collect())
             }
             (Num(a), Matrix(b)) | (Matrix(b), Num(a)) => Matrix(
@@ -150,15 +135,12 @@ impl NumStr
             _ => return Err("add err"),
         })
     }
-    pub fn sub(&self, b: &Self) -> Result<Self, &'static str>
-    {
-        Ok(match (self, b)
-        {
+    pub fn sub(&self, b: &Self) -> Result<Self, &'static str> {
+        Ok(match (self, b) {
             (Num(a), Num(b)) => Num(a - b.clone()),
             (Num(a), Vector(b)) => Vector(b.iter().map(|b| a - b.clone()).collect()),
             (Vector(a), Num(b)) => Vector(a.iter().map(|a| a - b.clone()).collect()),
-            (Vector(a), Vector(b)) if a.len() == b.len() =>
-            {
+            (Vector(a), Vector(b)) if a.len() == b.len() => {
                 Vector(a.iter().zip(b.iter()).map(|(a, b)| a - b.clone()).collect())
             }
             (Num(a), Matrix(b)) => Matrix(
@@ -193,10 +175,8 @@ impl NumStr
             _ => return Err("sub err"),
         })
     }
-    pub fn pow(&self, b: &Self) -> Result<Self, &'static str>
-    {
-        Ok(match (self, b)
-        {
+    pub fn pow(&self, b: &Self) -> Result<Self, &'static str> {
+        Ok(match (self, b) {
             (Num(a), Num(b)) => Num(a.pow(b.clone())),
             (Num(a), Vector(b)) => Vector(b.iter().map(|b| a.pow(b.clone())).collect()),
             (Vector(a), Num(b)) => Vector(a.iter().map(|a| a.pow(b.clone())).collect()),
@@ -211,53 +191,35 @@ impl NumStr
                     .map(|b| b.iter().map(|b| a.pow(b.clone())).collect())
                     .collect(),
             ),
-            (Matrix(a), Num(b)) if a.len() == a[0].len() =>
-            {
-                if b.imag() == &0.0 && b.real().clone().fract() == 0.0
-                {
-                    if b.real() == &0.0
-                    {
+            (Matrix(a), Num(b)) if a.len() == a[0].len() => {
+                if b.imag() == &0.0 && b.real().clone().fract() == 0.0 {
+                    if b.real() == &0.0 {
                         let mut mat = Vec::new();
-                        for i in 0..a.len()
-                        {
+                        for i in 0..a.len() {
                             let mut vec = Vec::new();
-                            for j in 0..a.len()
-                            {
-                                vec.push(
-                                    if i == j
-                                    {
-                                        Complex::with_val(a[0][0].prec(), 1)
-                                    }
-                                    else
-                                    {
-                                        Complex::new(a[0][0].prec())
-                                    },
-                                )
+                            for j in 0..a.len() {
+                                vec.push(if i == j {
+                                    Complex::with_val(a[0][0].prec(), 1)
+                                } else {
+                                    Complex::new(a[0][0].prec())
+                                })
                             }
                             mat.push(vec);
                         }
                         Matrix(mat)
-                    }
-                    else
-                    {
+                    } else {
                         let mut mat = Matrix(a.clone());
                         let c = b.real().to_f64().abs() as usize;
-                        for _ in 1..c
-                        {
+                        for _ in 1..c {
                             mat = mat.mul(&Matrix(a.clone()))?;
                         }
-                        if b.real() > &0.0
-                        {
+                        if b.real() > &0.0 {
                             mat
-                        }
-                        else
-                        {
+                        } else {
                             Matrix(inverse(mat.mat()?)?)
                         }
                     }
-                }
-                else
-                {
+                } else {
                     return Err("no imag/fractional support for powers");
                 }
             }
@@ -283,34 +245,26 @@ impl NumStr
             _ => return Err("pow err"),
         })
     }
-    pub fn str_is(&self, s: &str) -> bool
-    {
-        match self
-        {
+    pub fn str_is(&self, s: &str) -> bool {
+        match self {
             Str(s2) => s == s2,
             _ => false,
         }
     }
-    pub fn num(&self) -> Result<Complex, &'static str>
-    {
-        match self
-        {
+    pub fn num(&self) -> Result<Complex, &'static str> {
+        match self {
             Num(n) => Ok(n.clone()),
             _ => Err("failed to get number"),
         }
     }
-    pub fn vec(&self) -> Result<Vec<Complex>, &'static str>
-    {
-        match self
-        {
+    pub fn vec(&self) -> Result<Vec<Complex>, &'static str> {
+        match self {
             Vector(v) => Ok(v.clone()),
             _ => Err("failed to get vector"),
         }
     }
-    pub fn mat(&self) -> Result<Vec<Vec<Complex>>, &'static str>
-    {
-        match self
-        {
+    pub fn mat(&self) -> Result<Vec<Vec<Complex>>, &'static str> {
+        match self {
             Matrix(m) => Ok(m.clone()),
             _ => Err("failed to get matrix"),
         }

--- a/src/fraction.rs
+++ b/src/fraction.rs
@@ -1,23 +1,18 @@
 // as per continued fraction expansion
 use crate::Options;
 use rug::{float::Constant::Pi, Float};
-pub fn fraction(value: Float, options: Options) -> String
-{
+pub fn fraction(value: Float, options: Options) -> String {
     let prec = value.prec();
-    if value.clone().fract() == 0.0
-    {
+    if value.clone().fract() == 0.0 {
         return String::new();
     }
     let mut nums: Vec<Float> = vec![];
     let rt3 = Float::with_val(prec, 3).sqrt();
     let values = [
         Float::with_val(prec, 1.0),
-        if options.tau
-        {
+        if options.tau {
             2 * Float::with_val(prec, Pi)
-        }
-        else
-        {
+        } else {
             Float::with_val(prec, Pi)
         },
         Float::with_val(prec, 2).sqrt(),
@@ -25,41 +20,29 @@ pub fn fraction(value: Float, options: Options) -> String
         Float::with_val(prec, 2 + rt3.clone()).sqrt(),
         Float::with_val(prec, 2 - rt3).sqrt(),
     ];
-    let sign: String = if value < 0.0
-    {
+    let sign: String = if value < 0.0 {
         "-".to_string()
-    }
-    else
-    {
+    } else {
         "".to_string()
     };
     let val = value.abs();
     let (mut number, mut recip, mut fract, mut orig);
     let tau = if options.tau { "τ" } else { "π" };
-    for (i, constant) in values.iter().enumerate()
-    {
+    for (i, constant) in values.iter().enumerate() {
         orig = val.clone() / constant;
-        if orig.clone().fract() == 0.0
-        {
-            return if i == 0
-            {
+        if orig.clone().fract() == 0.0 {
+            return if i == 0 {
                 String::new()
-            }
-            else
-            {
+            } else {
                 format!(
                     "{}{}{}",
                     sign,
-                    if orig == 1.0
-                    {
+                    if orig == 1.0 {
                         "".to_string()
-                    }
-                    else
-                    {
+                    } else {
                         orig.to_integer().unwrap().to_string()
                     },
-                    match i
-                    {
+                    match i {
                         1 => tau,
                         2 => "sqrt(2)",
                         3 => "sqrt(3)",
@@ -72,15 +55,12 @@ pub fn fraction(value: Float, options: Options) -> String
         }
         number = orig.clone().fract();
         nums.clear();
-        for _ in 0..=options.frac_iter
-        {
+        for _ in 0..=options.frac_iter {
             recip = number.clone().recip();
             fract = recip.clone().fract();
-            if fract < 1e-6
-            {
+            if fract < 1e-6 {
                 let mut last = Float::with_val(prec, 1.0);
-                for j in (0..nums.len()).rev()
-                {
+                for j in (0..nums.len()).rev() {
                     last = recip.clone();
                     recip *= &nums[j];
                 }
@@ -91,21 +71,15 @@ pub fn fraction(value: Float, options: Options) -> String
                     || last.to_string().len() > options.decimal_places
                 {
                     String::new()
-                }
-                else
-                {
+                } else {
                     format!(
                         "{sign}{}{}{}",
-                        if last == 1 && i != 0
-                        {
+                        if last == 1 && i != 0 {
                             "".to_string()
-                        }
-                        else
-                        {
+                        } else {
                             last.to_string()
                         },
-                        match i
-                        {
+                        match i {
                             0 => "",
                             1 => tau,
                             2 => "sqrt(2)",
@@ -114,12 +88,9 @@ pub fn fraction(value: Float, options: Options) -> String
                             5 => "sqrt(2-sqrt(3))",
                             _ => "",
                         },
-                        if recip == 1
-                        {
+                        if recip == 1 {
                             "".to_string()
-                        }
-                        else
-                        {
+                        } else {
                             "/".to_owned() + &recip.to_string()
                         }
                     )

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -16,8 +16,7 @@ pub fn graph(
     deg: AngleType,
     prec: u32,
     watch: Option<Instant>,
-) -> JoinHandle<()>
-{
+) -> JoinHandle<()> {
     thread::spawn(move || {
         let mut fg = Figure::new();
         fg.set_enhanced_text(false);
@@ -37,81 +36,60 @@ pub fn graph(
         let yticks = Some((Fix((options.yr[1] - options.yr[0]) / 20.0), 1));
         let mut re_cap: [String; 6] = Default::default();
         let mut im_cap: [String; 6] = Default::default();
-        if !input[0].contains('x')
-        {
+        if !input[0].contains('x') {
             let mut re = Vec::new();
             let mut matrix = false;
             let mut x = (Vec::new(), Vec::new());
             let mut y = (Vec::new(), Vec::new());
             let mut z = (Vec::new(), Vec::new());
             let mut d3 = false;
-            for (i, f) in func.iter().enumerate()
-            {
-                re.push(match do_math(f.to_vec(), deg, prec).unwrap()
-                {
-                    Vector(n) =>
-                    {
-                        for j in &n
-                        {
-                            if j.real() != &0.0
-                            {
+            for (i, f) in func.iter().enumerate() {
+                re.push(match do_math(f.to_vec(), deg, prec).unwrap() {
+                    Vector(n) => {
+                        for j in &n {
+                            if j.real() != &0.0 {
                                 re_cap[i] = input[i].to_owned() + ":re";
                             }
-                            if j.imag() != &0.0
-                            {
+                            if j.imag() != &0.0 {
                                 im_cap[i] = input[i].to_owned() + ":im";
                             }
                         }
                         n
                     }
-                    Matrix(n) =>
-                    {
+                    Matrix(n) => {
                         matrix = true;
-                        d3 = if n[0].len() == 3
-                        {
+                        d3 = if n[0].len() == 3 {
                             true
-                        }
-                        else if n[0].len() == 2
-                        {
+                        } else if n[0].len() == 2 {
                             false
-                        }
-                        else
-                        {
+                        } else {
                             return;
                         };
                         x.0.push(n.iter().map(|x| x[0].real().to_f64()).collect::<Vec<f64>>());
                         x.1.push(n.iter().map(|x| x[0].imag().to_f64()).collect::<Vec<f64>>());
                         y.0.push(n.iter().map(|x| x[1].real().to_f64()).collect::<Vec<f64>>());
                         y.1.push(n.iter().map(|x| x[1].imag().to_f64()).collect::<Vec<f64>>());
-                        if d3
-                        {
+                        if d3 {
                             z.0.push(n.iter().map(|x| x[2].real().to_f64()).collect::<Vec<f64>>());
                             z.1.push(n.iter().map(|x| x[2].imag().to_f64()).collect::<Vec<f64>>());
                         }
-                        for k in n
-                        {
-                            for j in k
-                            {
-                                if j.real() != &0.0
-                                {
+                        for k in n {
+                            for j in k {
+                                if j.real() != &0.0 {
                                     re_cap[i] = input[i].to_owned() + ":re";
                                 }
-                                if j.imag() != &0.0
-                                {
+                                if j.imag() != &0.0 {
                                     im_cap[i] = input[i].to_owned() + ":im";
                                 }
                             }
                         }
                         continue;
                     }
-                    Num(n) =>
-                    {
-                        if n.real() != &0.0
-                        {
+                    Num(n) => {
+                        if n.real() != &0.0 {
                             re_cap[i] = input[i].to_owned() + ":re";
                         }
-                        if n.imag() != &0.0
-                        {
+                        if n.imag() != &0.0 {
                             im_cap[i] = input[i].to_owned() + ":im";
                         }
                         vec![
@@ -122,13 +100,10 @@ pub fn graph(
                     _ => return,
                 });
             }
-            if matrix
-            {
-                if d3
-                {
+            if matrix {
+                if d3 {
                     let n = vec![0.0; 3];
-                    for _ in 0..6 - func.len()
-                    {
+                    for _ in 0..6 - func.len() {
                         x.0.push(n.clone());
                         y.0.push(n.clone());
                         z.0.push(n.clone());
@@ -219,12 +194,9 @@ pub fn graph(
                             z.1[5].clone(),
                             &[Caption(&im_cap[5]), Color(im6col)],
                         );
-                }
-                else
-                {
+                } else {
                     let z = vec![0.0; 2];
-                    for _ in 0..6 - func.len()
-                    {
+                    for _ in 0..6 - func.len() {
                         x.0.push(z.clone());
                         y.0.push(z.clone());
                         x.1.push(z.clone());
@@ -296,12 +268,9 @@ pub fn graph(
                             &[Caption(&im_cap[5]), Color(im6col)],
                         );
                 }
-            }
-            else if re[0].len() == 2
-            {
+            } else if re[0].len() == 2 {
                 let z = vec![Complex::new(prec); 2];
-                for _ in 0..6 - func.len()
-                {
+                for _ in 0..6 - func.len() {
                     re.push(z.clone());
                 }
                 fg.axes2d()
@@ -369,12 +338,9 @@ pub fn graph(
                         [0.0, re[5][1].imag().to_f64()],
                         &[Caption(&im_cap[5]), Color(im6col)],
                     );
-            }
-            else if re[0].len() == 3
-            {
+            } else if re[0].len() == 3 {
                 let z = vec![Complex::new(prec); 3];
-                for _ in 0..6 - func.len()
-                {
+                for _ in 0..6 - func.len() {
                     re.push(z.clone());
                 }
                 let zticks = Some((Fix((options.zr[1] - options.zr[0]) / 20.0), 1));
@@ -461,15 +427,12 @@ pub fn graph(
                         &[Caption(&im_cap[5]), Color(im6col)],
                     );
             }
-        }
-        else if input[0].contains('y')
-        {
+        } else if input[0].contains('y') {
             let zticks = Some((Fix((options.zr[1] - options.zr[0]) / 20.0), 1));
             let mut re = vec![Vec::new(); 6];
             let mut im = vec![Vec::new(); 6];
             let (mut re2, mut im2);
-            for (i, f) in func.iter().enumerate()
-            {
+            for (i, f) in func.iter().enumerate() {
                 (re2, im2) = get_list_3d(f, options, deg, prec);
                 if re2
                     .iter()
@@ -477,9 +440,7 @@ pub fn graph(
                     .all(|i| i)
                 {
                     re2.clear();
-                }
-                else
-                {
+                } else {
                     re_cap[i] = input[i].to_owned() + ":re";
                 }
                 if im2
@@ -488,16 +449,13 @@ pub fn graph(
                     .all(|i| i)
                 {
                     im2.clear();
-                }
-                else
-                {
+                } else {
                     im_cap[i] = input[i].to_owned() + ":im";
                 }
                 re[i].extend(re2);
                 im[i].extend(im2);
             }
-            if re.iter().all(|x| x.is_empty()) && im.iter().all(|x| x.is_empty())
-            {
+            if re.iter().all(|x| x.is_empty()) && im.iter().all(|x| x.is_empty()) {
                 println!("No data to plot");
                 return;
             }
@@ -595,14 +553,11 @@ pub fn graph(
                     im[5].iter().map(|i| i[2]),
                     &[PointSymbol(options.point_style), Color(im6col)],
                 );
-        }
-        else
-        {
+        } else {
             let mut re = vec![Vec::new(); 6];
             let mut im = vec![Vec::new(); 6];
             let (mut re2, mut im2);
-            for (i, f) in func.iter().enumerate()
-            {
+            for (i, f) in func.iter().enumerate() {
                 (re2, im2) = get_list_2d(f, options, deg, prec);
                 if re2
                     .iter()
@@ -610,9 +565,7 @@ pub fn graph(
                     .all(|i| i)
                 {
                     re2.clear();
-                }
-                else
-                {
+                } else {
                     re_cap[i] = input[i].to_owned() + ":re";
                 }
                 if im2
@@ -621,21 +574,17 @@ pub fn graph(
                     .all(|i| i)
                 {
                     im2.clear();
-                }
-                else
-                {
+                } else {
                     im_cap[i] = input[i].to_owned() + ":im";
                 }
                 re[i].extend(re2);
                 im[i].extend(im2);
             }
-            if re.iter().all(|x| x.is_empty()) && im.iter().all(|x| x.is_empty())
-            {
+            if re.iter().all(|x| x.is_empty()) && im.iter().all(|x| x.is_empty()) {
                 println!("No data to plot");
                 return;
             }
-            if options.lines
-            {
+            if options.lines {
                 fg.axes2d()
                     .set_x_ticks(xticks, &[], &[])
                     .set_y_ticks(yticks, &[], &[])
@@ -713,9 +662,7 @@ pub fn graph(
                         im[5].iter().map(|x| x[1]),
                         &[PointSymbol(options.point_style), Color(im6col)],
                     );
-            }
-            else
-            {
+            } else {
                 fg.axes2d()
                     .set_x_ticks(xticks, &[], &[])
                     .set_y_ticks(yticks, &[], &[])
@@ -795,8 +742,7 @@ pub fn graph(
                     );
             }
         }
-        if let Some(time) = watch
-        {
+        if let Some(time) = watch {
             println!("{}ms", time.elapsed().as_millis());
         }
         fg.show().unwrap();
@@ -807,12 +753,9 @@ pub fn get_list_2d(
     range: Options,
     deg: AngleType,
     prec: u32,
-) -> (Vec<[f64; 2]>, Vec<[f64; 2]>)
-{
-    if let Num(n) = &func[0]
-    {
-        if func.len() == 1 && n.eq0()
-        {
+) -> (Vec<[f64; 2]>, Vec<[f64; 2]>) {
+    if let Num(n) = &func[0] {
+        if func.len() == 1 && n.eq0() {
             return (Vec::new(), Vec::new());
         }
     }
@@ -823,34 +766,28 @@ pub fn get_list_2d(
     let den = range.samples_2d;
     let den_range = (max - min) / den;
     let (mut n, mut num);
-    for i in 0..=den as i32
-    {
+    for i in 0..=den as i32 {
         n = min + i as f64 * den_range;
         num = match do_math(
             func.iter()
-                .map(|i| match i
-                {
+                .map(|i| match i {
                     Str(s) if s == "x" => Num(Complex::with_val(prec, n)),
                     _ => i.clone(),
                 })
                 .collect(),
             deg,
             prec,
-        )
-        {
-            Ok(n) => match n.num()
-            {
+        ) {
+            Ok(n) => match n.num() {
                 Ok(n) => n,
                 _ => continue,
             },
             Err(_) => continue,
         };
-        if num.real().is_finite()
-        {
+        if num.real().is_finite() {
             re.push([n, num.real().to_f64()]);
         }
-        if num.imag().is_finite()
-        {
+        if num.imag().is_finite() {
             im.push([n, num.imag().to_f64()]);
         }
     }
@@ -861,12 +798,9 @@ pub fn get_list_3d(
     range: Options,
     deg: AngleType,
     prec: u32,
-) -> (Vec<[f64; 3]>, Vec<[f64; 3]>)
-{
-    if let Num(n) = &func[0]
-    {
-        if func.len() == 1 && n.eq0()
-        {
+) -> (Vec<[f64; 3]>, Vec<[f64; 3]>) {
+    if let Num(n) = &func[0] {
+        if func.len() == 1 && n.eq0() {
             return (Vec::new(), Vec::new());
         }
     }
@@ -881,54 +815,45 @@ pub fn get_list_3d(
     let den_y_range = (max_y - min_y) / den;
     let (mut n, mut f, mut num);
     let mut modified: Vec<NumStr>;
-    for i in 0..=den as i32
-    {
+    for i in 0..=den as i32 {
         n = min_x + i as f64 * den_x_range;
         modified = func
             .iter()
-            .map(|i| match i
-            {
+            .map(|i| match i {
                 Str(s) if s == "x" => Num(Complex::with_val(prec, n)),
                 _ => i.clone(),
             })
             .collect();
-        for g in 0..=den as i32
-        {
+        for g in 0..=den as i32 {
             f = min_y + g as f64 * den_y_range;
             num = match do_math(
                 modified
                     .iter()
-                    .map(|j| match j
-                    {
+                    .map(|j| match j {
                         Str(s) if s == "y" => Num(Complex::with_val(prec, f)),
                         _ => j.clone(),
                     })
                     .collect(),
                 deg,
                 prec,
-            )
-            {
-                Ok(n) => match n.num()
-                {
+            ) {
+                Ok(n) => match n.num() {
                     Ok(n) => n,
                     _ => continue,
                 },
                 Err(_) => continue,
             };
-            if num.real().is_finite()
-            {
+            if num.real().is_finite() {
                 re.push([n, f, num.real().to_f64()]);
             }
-            if num.imag().is_finite()
-            {
+            if num.imag().is_finite() {
                 im.push([n, f, num.imag().to_f64()]);
             }
         }
     }
     (re, im)
 }
-pub fn can_graph(input: &str) -> bool
-{
+pub fn can_graph(input: &str) -> bool {
     input.contains('#')
         || input
             .replace("exp", "")

--- a/src/help.rs
+++ b/src/help.rs
@@ -1,5 +1,4 @@
-pub fn help()
-{
+pub fn help() {
     println!(
              "Usage: kalc [FLAGS] function_1 function_2 function_3...\n\
 FLAGS: --help (this message)\n\
@@ -117,7 +116,6 @@ w=>ω, W=>Ω, y=>ψ, Y=>Ψ, x=>χ, X=>Χ, z=>ζ, Z=>Ζ,\n\
 numbers/minus sign convert to superscript acting as exponents"
     );
 }
-pub fn get_help(s: &str)
-{
+pub fn get_help(s: &str) {
     println!("{}", s);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,8 +36,7 @@ use std::{
 // make pi not slow via vars
 // fix sum(k,k,2,{3,4})
 #[derive(Clone, Copy)]
-pub struct Options
-{
+pub struct Options {
     sci: bool,
     deg: AngleType,
     base: usize,
@@ -64,10 +63,8 @@ pub struct Options
     small_e: bool,
     debug: bool,
 }
-impl Default for Options
-{
-    fn default() -> Self
-    {
+impl Default for Options {
+    fn default() -> Self {
         Options {
             sci: false,
             deg: Radians,
@@ -97,8 +94,7 @@ impl Default for Options
         }
     }
 }
-fn main()
-{
+fn main() {
     let mut options = Options::default();
     let mut watch = None;
     let mut handles: Vec<JoinHandle<()>> = Vec::new();
@@ -110,16 +106,12 @@ fn main()
         var("USERNAME").unwrap()
     );
     let mut args = args().collect::<Vec<String>>();
-    if file_opts(&mut options, file_path) || arg_opts(&mut options, &mut args)
-    {
+    if file_opts(&mut options, file_path) || arg_opts(&mut options, &mut args) {
         std::process::exit(1);
     }
-    let mut vars: Vec<[String; 2]> = if options.allow_vars
-    {
+    let mut vars: Vec<[String; 2]> = if options.allow_vars {
         get_vars(options.prec)
-    }
-    else
-    {
+    } else {
         Vec::new()
     };
     let mut old = vars.clone();
@@ -130,34 +122,27 @@ fn main()
         "C:\\Users\\{}\\AppData\\Roaming\\kalc.vars",
         var("USERNAME").unwrap()
     );
-    if File::open(file_path).is_ok() && options.allow_vars
-    {
+    if File::open(file_path).is_ok() && options.allow_vars {
         let lines = BufReader::new(File::open(file_path).unwrap())
             .lines()
             .map(|l| l.unwrap())
             .collect::<Vec<String>>();
         let mut split;
-        for i in lines
-        {
+        for i in lines {
             split = i.split('=');
             let l = split.next().unwrap().to_string();
             let r = split.next().unwrap().to_string();
-            for (i, j) in vars.clone().iter().enumerate()
-            {
-                if j[0].chars().count() <= l.chars().count()
-                {
+            for (i, j) in vars.clone().iter().enumerate() {
+                if j[0].chars().count() <= l.chars().count() {
                     vars.insert(i, [l, r]);
                     break;
                 }
             }
         }
     }
-    if !stdin().is_terminal()
-    {
-        for line in stdin().lock().lines()
-        {
-            if !line.as_ref().unwrap().is_empty()
-            {
+    if !stdin().is_terminal() {
+        for line in stdin().lock().lines() {
+            if !line.as_ref().unwrap().is_empty() {
                 args.push(line.unwrap());
             }
         }
@@ -169,8 +154,7 @@ fn main()
         "C:\\Users\\{}\\AppData\\Roaming\\kalc.history",
         var("USERNAME").unwrap()
     );
-    if File::open(file_path).is_err()
-    {
+    if File::open(file_path).is_err() {
         File::create(file_path).unwrap();
     }
     let mut file = OpenOptions::new().append(true).open(file_path).unwrap();
@@ -195,22 +179,17 @@ fn main()
     );
     let mut end = 0;
     let mut exit = false;
-    'main: loop
-    {
-        if exit
-        {
-            for handle in handles
-            {
+    'main: loop {
+        if exit {
+            for handle in handles {
                 handle.join().unwrap();
             }
             break;
         }
         input.clear();
         frac = 0;
-        if !args.is_empty()
-        {
-            if options.debug
-            {
+        if !args.is_empty() {
+            if options.debug {
                 watch = Some(std::time::Instant::now());
             }
             input = args.first().unwrap().chars().collect();
@@ -226,19 +205,16 @@ fn main()
                     )
                     .replace('_', &format!("({})", last.iter().collect::<String>())),
                     options,
-                )
-                {
+                ) {
                     Ok(f) => f,
-                    Err(s) =>
-                    {
+                    Err(s) => {
                         println!("{}", s);
                         return;
                     }
                 },
                 options,
             );
-            if let Some(time) = watch
-            {
+            if let Some(time) = watch {
                 print!(" {}", time.elapsed().as_nanos());
             }
             if !(can_graph(&input_var(
@@ -246,27 +222,20 @@ fn main()
                 &vars,
                 None,
                 options,
-            )))
-            {
+            ))) {
                 println!();
             }
             last = input.clone();
-            if args.is_empty()
-            {
+            if args.is_empty() {
                 exit = true;
             }
-        }
-        else
-        {
-            if options.prompt
-            {
+        } else {
+            if options.prompt {
                 print!(
                     "\x1B[2K\x1B[1G{}> \x1b[0m",
                     if options.color { "\x1b[94m" } else { "" }
                 );
-            }
-            else
-            {
+            } else {
                 print!("\x1B[2K\x1B[1G");
             }
             stdout().flush().unwrap();
@@ -286,24 +255,18 @@ fn main()
                 .chars()
                 .collect::<Vec<char>>();
             start = 0;
-            'outer: loop
-            {
+            'outer: loop {
                 c = read_single_char();
-                if options.debug
-                {
+                if options.debug {
                     watch = Some(std::time::Instant::now());
                 }
-                match c
-                {
-                    '\n' =>
-                    {
+                match c {
+                    '\n' => {
                         end = start + get_terminal_width() - if options.prompt { 3 } else { 0 };
-                        if end > input.len()
-                        {
+                        if end > input.len() {
                             end = input.len()
                         }
-                        if !options.real_time_output
-                        {
+                        if !options.real_time_output {
                             frac = print_concurrent(&input, &last, &vars, options, start, end);
                         }
                         if !(can_graph(&input_var(
@@ -311,27 +274,21 @@ fn main()
                             &vars,
                             None,
                             options,
-                        )))
-                        {
+                        ))) {
                             println!();
                         }
-                        if !input.is_empty()
-                        {
+                        if !input.is_empty() {
                             println!("{}", "\n".repeat(frac));
                         }
                         end = 0;
                         break;
                     }
-                    '\x08' =>
-                    {
-                        if placement - start == 0 && start != 0
-                        {
+                    '\x08' => {
+                        if placement - start == 0 && start != 0 {
                             start -= 1;
                         }
-                        if placement == 0
-                        {
-                            if input.is_empty()
-                            {
+                        if placement == 0 {
+                            if input.is_empty() {
                                 clear(&input, start, end, options);
                                 stdout().flush().unwrap();
                             }
@@ -340,33 +297,23 @@ fn main()
                         placement -= 1;
                         input.remove(placement);
                         end = start + get_terminal_width() - if options.prompt { 3 } else { 0 };
-                        if end > input.len()
-                        {
+                        if end > input.len() {
                             end = input.len()
                         }
-                        if i == max
-                        {
+                        if i == max {
                             current = input.clone();
-                        }
-                        else
-                        {
+                        } else {
                             lines[i as usize] = input.clone().iter().collect::<String>();
                         }
-                        frac = if input.is_empty()
-                        {
+                        frac = if input.is_empty() {
                             0
-                        }
-                        else if options.real_time_output
-                        {
+                        } else if options.real_time_output {
                             print_concurrent(&input, &last, &vars, options, start, end)
-                        }
-                        else
-                        {
+                        } else {
                             clear(&input, start, end, options);
                             0
                         };
-                        if let Some(time) = watch
-                        {
+                        if let Some(time) = watch {
                             let time = time.elapsed().as_nanos();
                             print!(
                                 " {}{}",
@@ -375,18 +322,14 @@ fn main()
                                     time.to_string().len() + 1 + end - start - (placement - start)
                                 )
                             );
-                        }
-                        else
-                        {
+                        } else {
                             print!("{}", "\x08".repeat(end - start - (placement - start)));
                         }
-                        if placement == 0 && input.is_empty()
-                        {
+                        if placement == 0 && input.is_empty() {
                             clear(&input, start, end, options);
                         }
                     }
-                    '\x11' =>
-                    {
+                    '\x11' => {
                         //end
                         placement = input.len();
                         end = input.len();
@@ -394,23 +337,17 @@ fn main()
                             > input.len()
                         {
                             0
-                        }
-                        else
-                        {
+                        } else {
                             input.len()
                                 - (get_terminal_width() - if options.prompt { 3 } else { 0 })
                         };
-                        if options.real_time_output
-                        {
+                        if options.real_time_output {
                             frac = print_concurrent(&input, &last, &vars, options, start, end);
-                        }
-                        else
-                        {
+                        } else {
                             clear(&input, start, end, options);
                         }
                     }
-                    '\x10' =>
-                    {
+                    '\x10' => {
                         //home
                         placement = 0;
                         start = 0;
@@ -418,23 +355,17 @@ fn main()
                             > input.len()
                         {
                             input.len()
-                        }
-                        else
-                        {
+                        } else {
                             get_terminal_width() - if options.prompt { 3 } else { 0 }
                         };
-                        if options.real_time_output
-                        {
+                        if options.real_time_output {
                             frac = print_concurrent(&input, &last, &vars, options, start, end);
-                        }
-                        else
-                        {
+                        } else {
                             clear(&input, start, end, options);
                         }
                         print!("{}", "\x08".repeat(end - start - (placement - start)));
                     }
-                    '\x1D' =>
-                    {
+                    '\x1D' => {
                         // up history
                         i -= if i > 0 { 1 } else { 0 };
                         input = lines[i as usize].clone().chars().collect::<Vec<char>>();
@@ -444,31 +375,23 @@ fn main()
                             > input.len()
                         {
                             0
-                        }
-                        else
-                        {
+                        } else {
                             input.len()
                                 - (get_terminal_width() - if options.prompt { 3 } else { 0 })
                         };
-                        if options.real_time_output
-                        {
+                        if options.real_time_output {
                             frac = print_concurrent(&input, &last, &vars, options, start, end);
-                        }
-                        else
-                        {
+                        } else {
                             clear(&input, start, end, options);
                         }
                     }
-                    '\x1E' =>
-                    {
+                    '\x1E' => {
                         // down history
                         i += 1;
-                        if i >= max
-                        {
+                        if i >= max {
                             input = current.clone();
                             i = max;
-                            if input.is_empty()
-                            {
+                            if input.is_empty() {
                                 placement = 0;
                                 start = 0;
                                 end = input.len();
@@ -476,9 +399,7 @@ fn main()
                                 stdout().flush().unwrap();
                                 continue 'outer;
                             }
-                        }
-                        else
-                        {
+                        } else {
                             input = lines[i as usize].clone().chars().collect::<Vec<char>>();
                         }
                         placement = input.len();
@@ -487,87 +408,64 @@ fn main()
                             > input.len()
                         {
                             0
-                        }
-                        else
-                        {
+                        } else {
                             input.len()
                                 - (get_terminal_width() - if options.prompt { 3 } else { 0 })
                         };
-                        if options.real_time_output
-                        {
+                        if options.real_time_output {
                             frac = print_concurrent(&input, &last, &vars, options, start, end);
-                        }
-                        else
-                        {
+                        } else {
                             clear(&input, start, end, options);
                         }
                     }
-                    '\x1B' =>
-                    {
+                    '\x1B' => {
                         // go left
-                        if placement - start == 0 && placement != 0 && start != 0
-                        {
+                        if placement - start == 0 && placement != 0 && start != 0 {
                             start -= 1;
                             placement -= 1;
                             end = start + get_terminal_width() - if options.prompt { 3 } else { 0 };
-                            if end > input.len()
-                            {
+                            if end > input.len() {
                                 end = input.len()
                             }
                             clear(&input, start, end, options);
                             print!("{}", "\x08".repeat(end - start - (placement - start)))
-                        }
-                        else if placement != 0
-                        {
+                        } else if placement != 0 {
                             placement -= 1;
                             print!("\x08");
                         }
                     }
-                    '\x1C' =>
-                    {
+                    '\x1C' => {
                         // go right
                         end = start + get_terminal_width() - if options.prompt { 3 } else { 0 };
-                        if end > input.len()
-                        {
+                        if end > input.len() {
                             end = input.len()
                         }
-                        if placement == end && end != input.len()
-                        {
+                        if placement == end && end != input.len() {
                             start += 1;
                             placement += 1;
                             end += 1;
                             clear(&input, start, end, options);
-                        }
-                        else if placement != input.len()
-                        {
+                        } else if placement != input.len() {
                             placement += 1;
                             print!("\x1b[1C")
                         }
                     }
-                    '\x12' =>
-                    {
+                    '\x12' => {
                         //alt+left
-                        if placement != 0
-                        {
+                        if placement != 0 {
                             let s = placement;
                             let mut hit = false;
-                            for (i, j) in input[..s].iter().enumerate().rev()
-                            {
-                                if !j.is_alphanumeric()
-                                {
-                                    if hit
-                                    {
+                            for (i, j) in input[..s].iter().enumerate().rev() {
+                                if !j.is_alphanumeric() {
+                                    if hit {
                                         placement = i + 1;
                                         break;
                                     }
-                                }
-                                else
-                                {
+                                } else {
                                     hit = true;
                                 }
                             }
-                            if placement <= start
-                            {
+                            if placement <= start {
                                 end -= start - placement;
                                 start = start - (start - placement);
                                 clear(&input, start, end, options);
@@ -577,94 +475,64 @@ fn main()
                                         get_terminal_width() - if options.prompt { 3 } else { 0 }
                                     )
                                 );
-                            }
-                            else if placement == s
-                            {
+                            } else if placement == s {
                                 placement = 0;
                                 print!("{}", "\x08".repeat(s));
-                            }
-                            else
-                            {
+                            } else {
                                 print!("{}", "\x08".repeat(s - placement));
                             }
                         }
                     }
-                    '\x13' =>
-                    {
+                    '\x13' => {
                         //alt+right
-                        if placement != input.len()
-                        {
+                        if placement != input.len() {
                             let s = placement;
                             let mut hit = false;
-                            for (i, j) in input[s + 1..].iter().enumerate()
-                            {
-                                if !j.is_alphanumeric()
-                                {
-                                    if hit
-                                    {
+                            for (i, j) in input[s + 1..].iter().enumerate() {
+                                if !j.is_alphanumeric() {
+                                    if hit {
                                         placement += i + 1;
                                         break;
                                     }
-                                }
-                                else
-                                {
+                                } else {
                                     hit = true;
                                 }
                             }
-                            if placement >= end
-                            {
+                            if placement >= end {
                                 start += placement - end;
                                 end = end + (placement - end);
                                 clear(&input, start, end, options);
-                            }
-                            else if placement == s
-                            {
+                            } else if placement == s {
                                 placement = input.len();
                                 print!("{}", "\x1b[1C".repeat(input.len() - s));
-                            }
-                            else
-                            {
+                            } else {
                                 print!("{}", "\x1b[1C".repeat(placement - s));
                             }
                         }
                     }
-                    '\0' =>
-                    {}
-                    _ =>
-                    {
+                    '\0' => {}
+                    _ => {
                         input.insert(placement, c);
                         placement += 1;
                         end = start + get_terminal_width() - if options.prompt { 3 } else { 0 } + 1;
-                        if end > input.len()
-                        {
+                        if end > input.len() {
                             end = input.len()
-                        }
-                        else if placement == end
-                        {
+                        } else if placement == end {
                             start += 1;
-                        }
-                        else
-                        {
+                        } else {
                             end -= 1;
                         }
-                        if i == max
-                        {
+                        if i == max {
                             current = input.clone();
-                        }
-                        else
-                        {
+                        } else {
                             lines[i as usize] = input.clone().iter().collect::<String>();
                         }
-                        if options.real_time_output
-                        {
+                        if options.real_time_output {
                             frac = print_concurrent(&input, &last, &vars, options, start, end);
-                        }
-                        else
-                        {
+                        } else {
                             clear(&input, start, end, options)
                         }
-                        if let Some(time) = watch
-                        {
+                        if let Some(time) = watch {
                             let time = time.elapsed().as_nanos();
                             print!(
                                 " {}{}",
@@ -673,53 +541,43 @@ fn main()
                                     time.to_string().len() + 1 + end - start - (placement - start)
                                 )
                             );
-                        }
-                        else if placement != input.len()
-                        {
+                        } else if placement != input.len() {
                             print!("{}", "\x08".repeat(end - start - (placement - start)));
                         }
                     }
                 }
                 stdout().flush().unwrap();
             }
-            if input.is_empty()
-            {
+            if input.is_empty() {
                 continue;
             }
-            match input.iter().collect::<String>().as_str()
-            {
-                "color" =>
-                {
+            match input.iter().collect::<String>().as_str() {
+                "color" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     options.color = !options.color;
                 }
-                "prompt" =>
-                {
+                "prompt" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     options.prompt = !options.prompt;
                 }
-                "deg" =>
-                {
+                "deg" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     options.deg = Degrees;
                 }
-                "rad" =>
-                {
+                "rad" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     options.deg = Radians;
                 }
-                "grad" =>
-                {
+                "grad" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     options.deg = Gradians;
                 }
-                "rt" =>
-                {
+                "rt" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     options.real_time_output = !options.real_time_output;
@@ -727,90 +585,73 @@ fn main()
                 "tau" => options.tau = true,
                 "pi" => options.tau = false,
                 "small_e" => options.small_e = !options.small_e,
-                "sci" | "scientific" =>
-                {
+                "sci" | "scientific" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     options.sci = !options.sci;
                 }
-                "clear" =>
-                {
+                "clear" => {
                     print!("\x1B[2J\x1B[1;1H");
                     stdout().flush().unwrap();
                 }
-                "debug" =>
-                {
+                "debug" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     options.debug = !options.debug;
                     watch = None;
                 }
-                "help" =>
-                {
+                "help" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     help();
                     continue;
                 }
-                "line" | "lines" =>
-                {
+                "line" | "lines" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     options.lines = !options.lines;
                 }
-                "polar" =>
-                {
+                "polar" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     options.polar = !options.polar;
                 }
-                "frac" =>
-                {
+                "frac" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     options.frac = !options.frac;
                 }
-                "multi" =>
-                {
+                "multi" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     options.multi = !options.multi;
                 }
-                "tabbed" =>
-                {
+                "tabbed" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     options.tabbed = !options.tabbed;
                 }
-                "comma" =>
-                {
+                "comma" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     options.comma = !options.comma;
                 }
-                "history" =>
-                {
+                "history" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
-                    for l in lines
-                    {
+                    for l in lines {
                         println!("{}", l);
                     }
                     continue;
                 }
-                "vars" | "variables" =>
-                {
+                "vars" | "variables" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     let mut n;
-                    for v in vars.iter()
-                    {
-                        if v[0].contains('(')
-                        {
+                    for v in vars.iter() {
+                        if v[0].contains('(') {
                             println!("{}={}", v[0], v[1]);
-                        }
-                        else
-                        {
+                        } else {
                             n = get_output(
                                 &options,
                                 &do_math(
@@ -830,49 +671,40 @@ fn main()
                         }
                     }
                 }
-                "lvars" =>
-                {
+                "lvars" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
-                    for v in vars.iter()
-                    {
+                    for v in vars.iter() {
                         println!("{}={}", v[0], v[1]);
                     }
                 }
-                "version" =>
-                {
+                "version" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
                     continue;
                 }
-                "exit" | "quit" | "break" =>
-                {
+                "exit" | "quit" | "break" => {
                     print!("\x1b[A\x1B[2K\x1B[1G");
                     stdout().flush().unwrap();
                     break;
                 }
-                _ =>
-                {
+                _ => {
                     let n = input.iter().collect::<String>();
                     split = n.splitn(2, ' ');
                     let next = split.next().unwrap();
-                    if next == "history"
-                    {
+                    if next == "history" {
                         print!("\x1b[A\x1B[2K\x1B[1G");
                         stdout().flush().unwrap();
                         r = split.next().unwrap();
-                        for i in lines
-                        {
-                            if i.contains(r)
-                            {
+                        for i in lines {
+                            if i.contains(r) {
                                 println!("{}", i);
                             }
                         }
                         continue;
                     }
-                    if next == "help"
-                    {
+                    if next == "help" {
                         print!("\x1b[A\x1B[2K\x1B[1G");
                         stdout().flush().unwrap();
                         get_help(split.next().unwrap());
@@ -889,11 +721,9 @@ fn main()
                 &unmod_lines,
             );
         }
-        if input.ends_with(&['='])
-        {
+        if input.ends_with(&['=']) {
             l = input[..input.len() - 1].iter().collect::<String>();
-            match l.as_str()
-            {
+            match l.as_str() {
                 "color" => println!("{}", options.color),
                 "prompt" => println!("{}", options.prompt),
                 "rt" => println!("{}", options.real_time_output),
@@ -915,18 +745,13 @@ fn main()
                 "frac_iter" => println!("{}", options.frac_iter),
                 "2d" => println!("{}", options.samples_2d),
                 "3d" => println!("{}", options.samples_3d),
-                _ =>
-                {
-                    for i in match get_func(&input_var(&l, &vars, None, options), options)
-                    {
+                _ => {
+                    for i in match get_func(&input_var(&l, &vars, None, options), options) {
                         Ok(n) => n,
                         Err(_) => continue,
-                    }
-                    {
-                        match i
-                        {
-                            Num(n) =>
-                            {
+                    } {
+                        match i {
+                            Num(n) => {
                                 let n = get_output(&options, &n);
                                 print!(
                                     "{}{}{}",
@@ -935,12 +760,10 @@ fn main()
                                     if options.color { "\x1b[0m" } else { "" }
                                 )
                             }
-                            Vector(n) =>
-                            {
+                            Vector(n) => {
                                 let mut str = String::new();
                                 let mut num;
-                                for i in n
-                                {
+                                for i in n {
                                     num = get_output(&options, &i);
                                     str.push_str(&format!(
                                         "{}{}{},",
@@ -952,14 +775,11 @@ fn main()
                                 str.pop();
                                 print!("{{{}}}", str)
                             }
-                            Matrix(n) =>
-                            {
+                            Matrix(n) => {
                                 let mut str = String::new();
                                 let mut num;
-                                for i in n
-                                {
-                                    for j in i
-                                    {
+                                for i in n {
+                                    for j in i {
                                         num = get_output(&options, &j);
                                         str.push_str(&format!(
                                             "{}{}{},",
@@ -996,14 +816,11 @@ fn main()
             let s = split.next().unwrap().replace(' ', "");
             l = s;
             r = split.next().unwrap();
-            if l.is_empty()
-            {
+            if l.is_empty() {
                 continue;
             }
-            match l.as_str()
-            {
-                "point" =>
-                {
+            match l.as_str() {
+                "point" => {
                     if matches!(
                         r,
                         "." | "+"
@@ -1019,57 +836,39 @@ fn main()
                             | "D"
                             | "r"
                             | "R"
-                    )
-                    {
+                    ) {
                         options.point_style = r.chars().next().unwrap();
-                    }
-                    else
-                    {
+                    } else {
                         println!("Invalid point type");
                     }
                     continue;
                 }
-                "base" =>
-                {
-                    options.base = match r.parse::<usize>()
-                    {
-                        Ok(n) =>
-                        {
-                            if !(2..=36).contains(&n)
-                            {
+                "base" => {
+                    options.base = match r.parse::<usize>() {
+                        Ok(n) => {
+                            if !(2..=36).contains(&n) {
                                 println!("Invalid base");
                                 options.base
-                            }
-                            else
-                            {
+                            } else {
                                 n
                             }
                         }
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid base");
                             options.base
                         }
                     };
                     continue;
                 }
-                "decimal" | "deci" | "decimals" =>
-                {
-                    if r == "-1"
-                    {
+                "decimal" | "deci" | "decimals" => {
+                    if r == "-1" {
                         options.decimal_places = usize::MAX - 1;
-                    }
-                    else if r == "-2"
-                    {
+                    } else if r == "-2" {
                         options.decimal_places = usize::MAX;
-                    }
-                    else
-                    {
-                        options.decimal_places = match r.parse::<usize>()
-                        {
+                    } else {
+                        options.decimal_places = match r.parse::<usize>() {
                             Ok(n) => n,
-                            Err(_) =>
-                            {
+                            Err(_) => {
                                 println!("Invalid decimal");
                                 options.decimal_places
                             }
@@ -1077,34 +876,24 @@ fn main()
                     }
                     continue;
                 }
-                "prec" | "precision" =>
-                {
-                    options.prec = if r == "0"
-                    {
+                "prec" | "precision" => {
+                    options.prec = if r == "0" {
                         println!("Invalid precision");
                         options.prec
-                    }
-                    else
-                    {
-                        match r.parse::<u32>()
-                        {
+                    } else {
+                        match r.parse::<u32>() {
                             Ok(n) => n,
-                            Err(_) =>
-                            {
+                            Err(_) => {
                                 println!("Invalid precision");
                                 options.prec
                             }
                         }
                     };
-                    if options.allow_vars
-                    {
+                    if options.allow_vars {
                         v = get_vars(options.prec);
-                        for i in &old
-                        {
-                            for (j, var) in vars.iter_mut().enumerate()
-                            {
-                                if v.len() > j && i[0] == v[j][0] && i[1] == var[1]
-                                {
+                        for i in &old {
+                            for (j, var) in vars.iter_mut().enumerate() {
+                                if v.len() > j && i[0] == v[j][0] && i[1] == var[1] {
                                     *var = v[j].clone();
                                 }
                             }
@@ -1113,24 +902,18 @@ fn main()
                     }
                     continue;
                 }
-                "xr" =>
-                {
-                    if r.contains(',')
-                    {
-                        options.xr[0] = match r.split(',').next().unwrap().parse::<f64>()
-                        {
+                "xr" => {
+                    if r.contains(',') {
+                        options.xr[0] = match r.split(',').next().unwrap().parse::<f64>() {
                             Ok(n) => n,
-                            Err(_) =>
-                            {
+                            Err(_) => {
                                 println!("Invalid x range");
                                 options.xr[0]
                             }
                         };
-                        options.xr[1] = match r.split(',').last().unwrap().parse::<f64>()
-                        {
+                        options.xr[1] = match r.split(',').last().unwrap().parse::<f64>() {
                             Ok(n) => n,
-                            Err(_) =>
-                            {
+                            Err(_) => {
                                 println!("Invalid x range");
                                 options.xr[1]
                             }
@@ -1138,24 +921,18 @@ fn main()
                         continue;
                     }
                 }
-                "yr" =>
-                {
-                    if r.contains(',')
-                    {
-                        options.yr[0] = match r.split(',').next().unwrap().parse::<f64>()
-                        {
+                "yr" => {
+                    if r.contains(',') {
+                        options.yr[0] = match r.split(',').next().unwrap().parse::<f64>() {
                             Ok(n) => n,
-                            Err(_) =>
-                            {
+                            Err(_) => {
                                 println!("Invalid y range");
                                 options.yr[0]
                             }
                         };
-                        options.yr[1] = match r.split(',').last().unwrap().parse::<f64>()
-                        {
+                        options.yr[1] = match r.split(',').last().unwrap().parse::<f64>() {
                             Ok(n) => n,
-                            Err(_) =>
-                            {
+                            Err(_) => {
                                 println!("Invalid y range");
                                 options.yr[1]
                             }
@@ -1163,24 +940,18 @@ fn main()
                         continue;
                     }
                 }
-                "zr" =>
-                {
-                    if r.contains(',')
-                    {
-                        options.zr[0] = match r.split(',').next().unwrap().parse::<f64>()
-                        {
+                "zr" => {
+                    if r.contains(',') {
+                        options.zr[0] = match r.split(',').next().unwrap().parse::<f64>() {
                             Ok(n) => n,
-                            Err(_) =>
-                            {
+                            Err(_) => {
                                 println!("Invalid z range");
                                 options.zr[0]
                             }
                         };
-                        options.zr[1] = match r.split(',').last().unwrap().parse::<f64>()
-                        {
+                        options.zr[1] = match r.split(',').last().unwrap().parse::<f64>() {
                             Ok(n) => n,
-                            Err(_) =>
-                            {
+                            Err(_) => {
                                 println!("Invalid z range");
                                 options.zr[1]
                             }
@@ -1188,39 +959,30 @@ fn main()
                         continue;
                     }
                 }
-                "frac_iter" =>
-                {
-                    options.frac_iter = match r.parse::<usize>()
-                    {
+                "frac_iter" => {
+                    options.frac_iter = match r.parse::<usize>() {
                         Ok(n) => n,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid frac_iter");
                             options.frac_iter
                         }
                     };
                     continue;
                 }
-                "2d" =>
-                {
-                    options.samples_2d = match r.parse::<f64>()
-                    {
+                "2d" => {
+                    options.samples_2d = match r.parse::<f64>() {
                         Ok(n) => n,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid 2d sample size");
                             options.samples_2d
                         }
                     };
                     continue;
                 }
-                "3d" =>
-                {
-                    options.samples_3d = match r.parse::<f64>()
-                    {
+                "3d" => {
+                    options.samples_3d = match r.parse::<f64>() {
                         Ok(n) => n,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid 3d sample size");
                             options.samples_3d
                         }
@@ -1229,37 +991,28 @@ fn main()
                 }
                 _ => (),
             }
-            for (i, v) in vars.iter().enumerate()
-            {
-                if v[0].split('(').next() == l.split('(').next()
-                {
-                    if r == "null"
-                    {
+            for (i, v) in vars.iter().enumerate() {
+                if v[0].split('(').next() == l.split('(').next() {
+                    if r == "null" {
                         vars.remove(i);
-                    }
-                    else
-                    {
+                    } else {
                         vars[i] = [l.to_string(), r.to_string()];
                     }
                     continue 'main;
                 }
             }
-            if r.is_empty()
-            {
+            if r.is_empty() {
                 println!("0");
                 stdout().flush().unwrap();
             }
-            for (i, j) in vars.iter().enumerate()
-            {
-                if j[0].chars().count() <= l.chars().count()
-                {
+            for (i, j) in vars.iter().enumerate() {
+                if j[0].chars().count() <= l.chars().count() {
                     vars.insert(i, [l.to_string(), r.to_string()]);
                     break;
                 }
             }
             continue;
-        }
-        else if input.contains(&'#')
+        } else if input.contains(&'#')
             || input_var(&input.iter().collect::<String>(), &vars, None, options)
                 .replace("exp", "")
                 .replace("max", "")
@@ -1280,10 +1033,8 @@ fn main()
                 .map(String::from)
                 .collect();
             funcs = Vec::new();
-            for i in &inputs
-            {
-                if i.is_empty()
-                {
+            for i in &inputs {
+                if i.is_empty() {
                     continue;
                 }
                 funcs.push(
@@ -1295,8 +1046,7 @@ fn main()
                             .replace("##ta##", "zeta")
                             .replace("##ma##", "normalize"),
                         options,
-                    )
-                    {
+                    ) {
                         Ok(f) => f,
                         _ => continue 'main,
                     },

--- a/src/math.rs
+++ b/src/math.rs
@@ -10,14 +10,11 @@ use crate::{
 };
 use rug::{float::Constant::Pi, ops::Pow, Complex, Float};
 use std::ops::{Shl, Shr};
-pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &'static str>
-{
-    if func.len() == 1
-    {
+pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &'static str> {
+    if func.len() == 1 {
         return Ok(func[0].clone());
     }
-    if func.is_empty()
-    {
+    if func.is_empty() {
         return Err("no function");
     }
     let mut function = func;
@@ -27,31 +24,23 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
     let (mut j, mut v, mut vec, mut mat);
     let mut len = 0;
     let mut place = Vec::new();
-    'outer: while i < function.len() - 1
-    {
-        if let Str(s) = &function[i]
-        {
-            if s == "{"
-            {
+    'outer: while i < function.len() - 1 {
+        if let Str(s) = &function[i] {
+            if s == "{" {
                 j = i + 1;
                 count = 1;
-                while count > 0
-                {
-                    if j >= function.len()
-                    {
+                while count > 0 {
+                    if j >= function.len() {
                         return Err("idk");
                     }
-                    match &function[j]
-                    {
+                    match &function[j] {
                         Str(s) if s == "{" => count += 1,
                         Str(s) if s == "}" => count -= 1,
-                        _ =>
-                        {}
+                        _ => {}
                     }
                     j += 1;
                 }
-                if i + 1 == j - 1
-                {
+                if i + 1 == j - 1 {
                     return Err("no interior vector");
                 }
                 v = function[i + 1..j - 1].to_vec();
@@ -59,90 +48,64 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                 count = 0;
                 vec = Vec::new();
                 mat = Vec::new();
-                for (f, n) in v.iter().enumerate()
-                {
-                    if let Str(s) = n
-                    {
-                        if s == "," && count == 0
-                        {
+                for (f, n) in v.iter().enumerate() {
+                    if let Str(s) = n {
+                        if s == "," && count == 0 {
                             let z = do_math(v[single..f].to_vec(), deg, prec)?;
-                            match z
-                            {
+                            match z {
                                 Num(n) => vec.push(n),
-                                Vector(n) if len == n.len() || single == 0 =>
-                                {
+                                Vector(n) if len == n.len() || single == 0 => {
                                     len = n.len();
                                     mat.push(n)
                                 }
                                 _ => return Err("probably unreachable"),
                             }
                             single = f + 1;
-                        }
-                        else if s == "{"
-                        {
+                        } else if s == "{" {
                             count += 1;
-                        }
-                        else if s == "}"
-                        {
+                        } else if s == "}" {
                             count -= 1;
                         }
                     }
                 }
-                if single != v.len()
-                {
+                if single != v.len() {
                     let z = do_math(v[single..].to_vec(), deg, prec)?;
-                    match z
-                    {
+                    match z {
                         Num(n) => vec.push(n),
                         Vector(n) if len == n.len() || single == 0 => mat.push(n),
                         _ => return Err("probably not reachable"),
                     }
                 }
                 function.drain(i..j);
-                if !mat.is_empty()
-                {
-                    if vec.is_empty()
-                    {
+                if !mat.is_empty() {
+                    if vec.is_empty() {
                         function.insert(i, Matrix(mat));
-                    }
-                    else
-                    {
+                    } else {
                         return Err("likely unreachable");
                     }
-                }
-                else
-                {
+                } else {
                     function.insert(i, Vector(vec));
                 }
-            }
-            else if s == "("
-            {
+            } else if s == "(" {
                 j = i + 1;
                 count = 1;
-                while count > 0
-                {
-                    if j >= function.len()
-                    {
+                while count > 0 {
+                    if j >= function.len() {
                         return Err("unsure");
                     }
-                    match &function[j]
-                    {
+                    match &function[j] {
                         Str(s) if s == "(" => count += 1,
                         Str(s) if s == ")" => count -= 1,
-                        _ =>
-                        {}
+                        _ => {}
                     }
                     j += 1;
                 }
-                if i + 1 == j - 1
-                {
+                if i + 1 == j - 1 {
                     return Err("no interior bracket");
                 }
                 v = function[i + 1..j - 1].to_vec();
-                if i != 0
-                {
-                    if let Str(k) = &function[i - 1]
-                    {
+                if i != 0 {
+                    if let Str(k) = &function[i - 1] {
                         if matches!(
                             k.as_str(),
                             "log"
@@ -160,33 +123,23 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                                 | "min"
                                 | "proj"
                                 | "project"
-                        )
-                        {
+                        ) {
                             count = 0;
-                            for (f, n) in v.iter().enumerate()
-                            {
-                                if let Str(s) = n
-                                {
-                                    if s == "," && count == 0
-                                    {
+                            for (f, n) in v.iter().enumerate() {
+                                if let Str(s) = n {
+                                    if s == "," && count == 0 {
                                         place.push(f);
-                                    }
-                                    else if s == "(" || s == "{"
-                                    {
+                                    } else if s == "(" || s == "{" {
                                         count += 1;
-                                    }
-                                    else if s == ")" || s == "}"
-                                    {
+                                    } else if s == ")" || s == "}" {
                                         count -= 1;
                                     }
                                 }
                             }
-                            if !place.is_empty()
-                            {
+                            if !place.is_empty() {
                                 function.drain(i..j);
                                 function.insert(i, do_math(v[..place[0]].to_vec(), deg, prec)?);
-                                for (k, l) in place.iter().enumerate()
-                                {
+                                for (k, l) in place.iter().enumerate() {
                                     function.insert(i + k + 1, Str(",".to_string()));
                                     function.insert(
                                         i + k + 2,
@@ -196,12 +149,10 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                                 }
                                 continue 'outer;
                             }
-                        }
-                        else if matches!(
+                        } else if matches!(
                             k.as_str(),
                             "sum" | "summation" | "prod" | "product" | "Σ" | "Π"
-                        )
-                        {
+                        ) {
                             i = j - 1;
                             continue;
                         }
@@ -215,18 +166,14 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
     }
     i = 0;
     let (mut a, mut b);
-    let to_deg = match deg
-    {
+    let to_deg = match deg {
         Degrees => Complex::with_val(prec, 180) / Complex::with_val(prec, Pi),
         Radians => Complex::with_val(prec, 1),
         Gradians => Complex::with_val(prec, 200) / Complex::with_val(prec, Pi),
     };
-    while i < function.len() - 1
-    {
-        if let Str(s) = &function[i].clone()
-        {
-            if s.len() > 1 && s.chars().next().unwrap().is_alphabetic()
-            {
+    while i < function.len() - 1 {
+        if let Str(s) = &function[i].clone() {
+            if s.len() > 1 && s.chars().next().unwrap().is_alphabetic() {
                 if s == "sum"
                     || s == "product"
                     || s == "prod"
@@ -235,22 +182,14 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                     || s == "Π"
                 {
                     place.clear();
-                    for (f, n) in function.iter().enumerate()
-                    {
-                        if let Str(s) = n
-                        {
-                            if s == "," && count == 1
-                            {
+                    for (f, n) in function.iter().enumerate() {
+                        if let Str(s) = n {
+                            if s == "," && count == 1 {
                                 place.push(f);
-                            }
-                            else if s == "(" || s == "{"
-                            {
+                            } else if s == "(" || s == "{" {
                                 count += 1;
-                            }
-                            else if s == ")" || s == "}"
-                            {
-                                if count == 1
-                                {
+                            } else if s == ")" || s == "}" {
+                                if count == 1 {
                                     place.push(f);
                                     break;
                                 }
@@ -258,10 +197,8 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                             }
                         }
                     }
-                    if place.len() == 4
-                    {
-                        if let Str(l) = &function[place[0] + 1]
-                        {
+                    if place.len() == 4 {
+                        if let Str(l) = &function[place[0] + 1] {
                             function[i] = sum(
                                 function[i + 2..place[0]].to_vec(),
                                 l,
@@ -278,51 +215,32 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                                 prec,
                             )?;
                             function.drain(i + 1..=place[3]);
-                        }
-                        else
-                        {
+                        } else {
                             return Err("failed to get var for sum/prod");
                         }
-                    }
-                    else
-                    {
+                    } else {
                         return Err("not enough args for sum/prod");
                     }
-                }
-                else if let Matrix(a) = function[i + 1].clone()
-                {
-                    function[i] = match s.as_str()
-                    {
-                        "cofactor" | "cofactors" | "cof" =>
-                        {
-                            if a.len() == a[0].len() && a.len() > 1
-                            {
+                } else if let Matrix(a) = function[i + 1].clone() {
+                    function[i] = match s.as_str() {
+                        "cofactor" | "cofactors" | "cof" => {
+                            if a.len() == a[0].len() && a.len() > 1 {
                                 Matrix(cofactor(a))
-                            }
-                            else
-                            {
+                            } else {
                                 return Err("non square matrix");
                             }
                         }
-                        "minor" | "minors" =>
-                        {
-                            if a.len() == a[0].len() && a.len() > 1
-                            {
+                        "minor" | "minors" => {
+                            if a.len() == a[0].len() && a.len() > 1 {
                                 Matrix(minors(a))
-                            }
-                            else
-                            {
+                            } else {
                                 return Err("non square matrix");
                             }
                         }
-                        "adjugate" | "adj" =>
-                        {
-                            if a.len() == a[0].len() && a.len() > 1
-                            {
+                        "adjugate" | "adj" => {
+                            if a.len() == a[0].len() && a.len() > 1 {
                                 Matrix(transpose(cofactor(a)))
-                            }
-                            else
-                            {
+                            } else {
                                 return Err("non square matrix");
                             }
                         }
@@ -330,77 +248,54 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                         "transpose" | "trans" => Matrix(transpose(a)),
                         "len" | "length" => Num(Complex::with_val(prec, a.len())),
                         "wid" | "width" => Num(Complex::with_val(prec, a[0].len())),
-                        "tr" | "trace" =>
-                        {
+                        "tr" | "trace" => {
                             let mut n = Complex::new(prec);
-                            for (i, j) in a.iter().enumerate()
-                            {
-                                if j.len() == i
-                                {
+                            for (i, j) in a.iter().enumerate() {
+                                if j.len() == i {
                                     break;
                                 }
                                 n += j[i].clone();
                             }
                             Num(n)
                         }
-                        "det" | "determinant" =>
-                        {
-                            if a.len() == a[0].len()
-                            {
+                        "det" | "determinant" => {
+                            if a.len() == a[0].len() {
                                 Num(determinant(a))
-                            }
-                            else
-                            {
+                            } else {
                                 return Err("non square matrix");
                             }
                         }
-                        "part" =>
-                        {
-                            if function.len() > i + 3 && function[i + 2].str_is(",")
-                            {
-                                if function.len() > i + 5 && function[i + 4].str_is(",")
-                                {
+                        "part" => {
+                            if function.len() > i + 3 && function[i + 2].str_is(",") {
+                                if function.len() > i + 5 && function[i + 4].str_is(",") {
                                     let b = function[i + 3].num()?;
                                     let c = function[i + 5].num()?;
                                     function.drain(i + 2..i + 6);
                                     let n1 = b.clone().real().to_f64() as usize;
                                     let n2 = c.clone().real().to_f64() as usize;
-                                    if n1 <= a.len() && n1 != 0 && n2 <= a[0].len() && n2 != 0
-                                    {
+                                    if n1 <= a.len() && n1 != 0 && n2 <= a[0].len() && n2 != 0 {
                                         Num(a[n1 - 1][n2 - 1].clone())
-                                    }
-                                    else
-                                    {
+                                    } else {
                                         return Err("not in matrix");
                                     }
-                                }
-                                else
-                                {
+                                } else {
                                     let b = function[i + 3].num()?;
                                     function.drain(i + 2..i + 4);
                                     let n = b.clone().real().to_f64() as usize;
-                                    if n <= a.len() && n != 0
-                                    {
+                                    if n <= a.len() && n != 0 {
                                         Vector(a[n - 1].clone())
-                                    }
-                                    else
-                                    {
+                                    } else {
                                         return Err("not in matrix");
                                     }
                                 }
-                            }
-                            else
-                            {
+                            } else {
                                 return Err("no arg");
                             }
                         }
-                        "norm" =>
-                        {
+                        "norm" => {
                             let mut n = Complex::new(prec);
-                            for i in a
-                            {
-                                for j in i
-                                {
+                            for i in a {
+                                for j in i {
                                     n += j.abs().pow(2);
                                 }
                             }
@@ -421,43 +316,32 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                         )?,
                     };
                     function.remove(i + 1);
-                }
-                else if let Vector(a) = function[i + 1].clone()
-                {
-                    function[i] = match s.as_str()
-                    {
+                } else if let Vector(a) = function[i + 1].clone() {
+                    function[i] = match s.as_str() {
                         "len" | "length" => Num(Complex::with_val(prec, a.len())),
                         "abs" => Vector(a.iter().map(|x| x.clone().abs()).collect()),
-                        "norm" =>
-                        {
+                        "norm" => {
                             let mut n = Complex::new(prec);
-                            for i in a
-                            {
+                            for i in a {
                                 n += i.abs().pow(2);
                             }
                             Num(n.sqrt())
                         }
-                        "normalize" =>
-                        {
+                        "normalize" => {
                             let mut n = Complex::new(prec);
-                            for i in a.clone()
-                            {
+                            for i in a.clone() {
                                 n += i.pow(2);
                             }
                             Vector(a.iter().map(|x| x / n.clone().sqrt()).collect())
                         }
-                        "car" | "cartesian" =>
-                        {
-                            if a.len() == 2
-                            {
+                        "car" | "cartesian" => {
+                            if a.len() == 2 {
                                 let t = a[1].clone() / to_deg.clone();
                                 Vector(vec![
                                     a[0].clone() * t.clone().cos(),
                                     a[0].clone() * t.clone().sin(),
                                 ])
-                            }
-                            else if a.len() == 3
-                            {
+                            } else if a.len() == 3 {
                                 let t1 = a[1].clone() / to_deg.clone();
                                 let t2 = a[2].clone() / to_deg.clone();
                                 Vector(vec![
@@ -465,21 +349,16 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                                     a[0].clone() * t1.clone().sin() * t2.clone().sin(),
                                     a[0].clone() * t1.clone().cos(),
                                 ])
-                            }
-                            else
-                            {
+                            } else {
                                 return Err("incorrect polar form");
                             }
                         }
                         "polar" | "pol" => Vector(to_polar(a.clone(), to_deg.clone())),
-                        "angle" =>
-                        {
-                            if function.len() > i + 3 && function[i + 2].str_is(",")
-                            {
+                        "angle" => {
+                            if function.len() > i + 3 && function[i + 2].str_is(",") {
                                 let b = function[i + 3].vec()?;
                                 function.drain(i + 2..i + 4);
-                                if a.len() == 3 && b.len() == 3
-                                {
+                                if a.len() == 3 && b.len() == 3 {
                                     let c: Complex = a[0].clone().pow(2)
                                         + a[1].clone().pow(2)
                                         + a[2].clone().pow(2);
@@ -492,9 +371,7 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                                         / (c.sqrt() * d.sqrt()))
                                     .acos()
                                         * to_deg.clone())
-                                }
-                                else if a.len() == 2 && b.len() == 2
-                                {
+                                } else if a.len() == 2 && b.len() == 2 {
                                     let c: Complex = a[0].clone().pow(2) + a[1].clone().pow(2);
                                     let d: Complex = b[0].clone().pow(2) + b[1].clone().pow(2);
                                     Num(((a[0].clone() * b[0].clone()
@@ -502,79 +379,55 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                                         / (c.sqrt() * d.sqrt()))
                                     .acos()
                                         * to_deg.clone())
-                                }
-                                else
-                                {
+                                } else {
                                     return Err("cant decern angles");
                                 }
-                            }
-                            else
-                            {
+                            } else {
                                 return Err("no args");
                             }
                         }
-                        "cross" =>
-                        {
-                            if function.len() > i + 3 && function[i + 2].str_is(",")
-                            {
+                        "cross" => {
+                            if function.len() > i + 3 && function[i + 2].str_is(",") {
                                 let b = function[i + 3].vec()?;
                                 function.drain(i + 2..i + 4);
-                                if a.len() == 3 && b.len() == 3
-                                {
+                                if a.len() == 3 && b.len() == 3 {
                                     Vector(vec![
                                         a[1].clone() * &b[2] - a[2].clone() * &b[1],
                                         a[2].clone() * &b[0] - a[0].clone() * &b[2],
                                         a[0].clone() * &b[1] - a[1].clone() * &b[0],
                                     ])
-                                }
-                                else if a.len() == 2 && b.len() == 2
-                                {
+                                } else if a.len() == 2 && b.len() == 2 {
                                     Num(a[0].clone() * &b[1] - a[1].clone() * &b[0])
-                                }
-                                else
-                                {
+                                } else {
                                     return Err("cant cross");
                                 }
-                            }
-                            else
-                            {
+                            } else {
                                 return Err("no args");
                             }
                         }
-                        "project" | "proj" =>
-                        {
-                            if function.len() > i + 3 && function[i + 2].str_is(",")
-                            {
+                        "project" | "proj" => {
+                            if function.len() > i + 3 && function[i + 2].str_is(",") {
                                 let b = function[i + 3].clone();
-                                if b.vec()?.len() == a.len()
-                                {
+                                if b.vec()?.len() == a.len() {
                                     let mut dot = Complex::new(prec);
-                                    for i in a.iter().zip(b.vec()?.iter()).map(|(a, b)| a * b)
-                                    {
+                                    for i in a.iter().zip(b.vec()?.iter()).map(|(a, b)| a * b) {
                                         dot += i;
                                     }
                                     let mut norm = Complex::new(prec);
-                                    for i in b.vec()?
-                                    {
+                                    for i in b.vec()? {
                                         norm += i.abs().pow(2);
                                     }
                                     function.drain(i + 2..i + 4);
                                     Num(dot / norm).mul(&b)?
-                                }
-                                else
-                                {
+                                } else {
                                     return Err("cant project");
                                 }
-                            }
-                            else
-                            {
+                            } else {
                                 return Err("no args");
                             }
                         }
-                        "dot" =>
-                        {
-                            if function.len() > i + 3 && function[i + 2].str_is(",")
-                            {
+                        "dot" => {
+                            if function.len() > i + 3 && function[i + 2].str_is(",") {
                                 let mut n = Complex::new(prec);
                                 for i in a
                                     .iter()
@@ -585,30 +438,21 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                                 }
                                 function.drain(i + 2..i + 4);
                                 Num(n)
-                            }
-                            else
-                            {
+                            } else {
                                 return Err("no args");
                             }
                         }
-                        "part" =>
-                        {
-                            if function.len() > i + 3 && function[i + 2].str_is(",")
-                            {
+                        "part" => {
+                            if function.len() > i + 3 && function[i + 2].str_is(",") {
                                 let b = function[i + 3].num()?;
                                 function.drain(i + 2..i + 4);
                                 let n = b.clone().real().to_f64() as usize;
-                                if n <= a.len() && n != 0
-                                {
+                                if n <= a.len() && n != 0 {
                                     Num(a[n - 1].clone())
-                                }
-                                else
-                                {
+                                } else {
                                     return Err("out of range");
                                 }
-                            }
-                            else
-                            {
+                            } else {
                                 return Err("no args");
                             }
                         }
@@ -622,19 +466,14 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                         )?,
                     };
                     function.remove(i + 1);
-                }
-                else
-                {
-                    function[i] = if s == "rotate"
-                    {
+                } else {
+                    function[i] = if s == "rotate" {
                         a = function[i + 1].num()? / to_deg.clone();
                         Matrix(vec![
                             vec![a.clone().cos(), -a.clone().sin()],
                             vec![a.clone().sin(), a.cos()],
                         ])
-                    }
-                    else
-                    {
+                    } else {
                         do_functions(function[i + 1].clone(), deg, &mut function, i, &to_deg, s)?
                     };
                     function.remove(i + 1);
@@ -643,13 +482,10 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
         }
         i += 1;
     }
-    if function.len() > 1
-    {
+    if function.len() > 1 {
         i = function.len() - 2;
-        while i != 0
-        {
-            if !function[i].str_is("^")
-            {
+        while i != 0 {
+            if !function[i].str_is("^") {
                 i -= 1;
                 continue;
             }
@@ -660,23 +496,17 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
         }
     }
     i = 1;
-    while i < function.len() - 1
-    {
-        if let Str(s) = &function[i]
-        {
-            match s.as_str()
-            {
+    while i < function.len() - 1 {
+        if let Str(s) = &function[i] {
+            match s.as_str() {
                 "*" => function[i] = function[i - 1].mul(&function[i + 1])?,
                 "/" => function[i] = function[i - 1].div(&function[i + 1])?,
-                _ =>
-                {
+                _ => {
                     i += 1;
                     continue;
                 }
             }
-        }
-        else
-        {
+        } else {
             i += 1;
             continue;
         }
@@ -684,24 +514,18 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
         function.remove(i - 1);
     }
     i = 1;
-    while i < function.len() - 1
-    {
-        if let Str(s) = &function[i]
-        {
-            match s.as_str()
-            {
+    while i < function.len() - 1 {
+        if let Str(s) = &function[i] {
+            match s.as_str() {
                 "±" => function[i] = function[i - 1].pm(&function[i + 1])?,
                 "+" => function[i] = function[i - 1].add(&function[i + 1])?,
                 "-" => function[i] = function[i - 1].sub(&function[i + 1])?,
-                _ =>
-                {
+                _ => {
                     i += 1;
                     continue;
                 }
             }
-        }
-        else
-        {
+        } else {
             i += 1;
             continue;
         }
@@ -709,76 +533,62 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
         function.remove(i - 1);
     }
     i = 1;
-    while i < function.len() - 1
-    {
-        if let Str(s) = &function[i]
-        {
-            match s.as_str()
-            {
-                "%" =>
-                {
+    while i < function.len() - 1 {
+        if let Str(s) = &function[i] {
+            match s.as_str() {
+                "%" => {
                     function[i] = {
                         a = function[i - 1].num()?;
                         b = function[i + 1].num()?;
-                        if a.imag() == &0.0 && b.imag() == &0.0
-                        {
+                        if a.imag() == &0.0 && b.imag() == &0.0 {
                             Num(Complex::with_val(prec, a.real() % b.real()))
-                        }
-                        else
-                        {
+                        } else {
                             let c = -a.clone() / b.clone();
                             Num(a + b * (c.real().clone().ceil() + c.imag().clone().ceil()))
                         }
                     }
                 }
-                "<" =>
-                {
+                "<" => {
                     function[i] = Num(Complex::with_val(
                         prec,
                         (function[i - 1].num()?.abs().real() < function[i + 1].num()?.abs().real())
                             as i32,
                     ))
                 }
-                ">" =>
-                {
+                ">" => {
                     function[i] = Num(Complex::with_val(
                         prec,
                         (function[i - 1].num()?.abs().real() > function[i + 1].num()?.abs().real())
                             as i32,
                     ))
                 }
-                ">=" =>
-                {
+                ">=" => {
                     function[i] = Num(Complex::with_val(
                         prec,
                         (function[i - 1].num()?.abs().real() >= function[i + 1].num()?.abs().real())
                             as i32,
                     ))
                 }
-                "<=" =>
-                {
+                "<=" => {
                     function[i] = Num(Complex::with_val(
                         prec,
                         (function[i - 1].num()?.abs().real() <= function[i + 1].num()?.abs().real())
                             as i32,
                     ))
                 }
-                "==" =>
-                {
+                "==" => {
                     function[i] = Num(Complex::with_val(
                         prec,
                         (function[i - 1].num()? == function[i + 1].num()?) as i32,
                     ))
                 }
-                "!=" =>
-                {
+                "!=" => {
                     function[i] = Num(Complex::with_val(
                         prec,
                         (function[i - 1].num()? != function[i + 1].num()?) as i32,
                     ))
                 }
-                ">>" =>
-                {
+                ">>" => {
                     function[i] = Num(Complex::with_val(
                         prec,
                         function[i - 1].num()?.shr(
@@ -790,8 +600,7 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                         ),
                     ))
                 }
-                "<<" =>
-                {
+                "<<" => {
                     function[i] = Num(Complex::with_val(
                         prec,
                         function[i - 1].num()?.shl(
@@ -803,15 +612,12 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                         ),
                     ))
                 }
-                _ =>
-                {
+                _ => {
                     i += 1;
                     continue;
                 }
             }
-        }
-        else
-        {
+        } else {
             i += 1;
             continue;
         }
@@ -819,14 +625,10 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
         function.remove(i - 1);
     }
     i = 1;
-    while i < function.len() - 1
-    {
-        if let Str(s) = &function[i]
-        {
-            match s.as_str()
-            {
-                "&&" =>
-                {
+    while i < function.len() - 1 {
+        if let Str(s) = &function[i] {
+            match s.as_str() {
+                "&&" => {
                     a = function[i - 1].num()?;
                     b = function[i - 1].num()?;
                     function[i] = Num(Complex::with_val(
@@ -837,8 +639,7 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                             && b.real() == &1.0) as i32,
                     ))
                 }
-                "||" =>
-                {
+                "||" => {
                     a = function[i - 1].num()?;
                     b = function[i - 1].num()?;
                     function[i] = Num(Complex::with_val(
@@ -849,15 +650,12 @@ pub fn do_math(func: Vec<NumStr>, deg: AngleType, prec: u32) -> Result<NumStr, &
                             as i32,
                     ))
                 }
-                _ =>
-                {
+                _ => {
                     i += 1;
                     continue;
                 }
             }
-        }
-        else
-        {
+        } else {
             i += 1;
             continue;
         }
@@ -873,20 +671,15 @@ fn do_functions(
     k: usize,
     to_deg: &Complex,
     s: &str,
-) -> Result<NumStr, &'static str>
-{
+) -> Result<NumStr, &'static str> {
     let mut vec = Vec::new();
-    if function.len() > k + 3 && function[k + 2].str_is(",")
-    {
+    if function.len() > k + 3 && function[k + 2].str_is(",") {
         let b = function[k + 3].clone();
         function.drain(k + 2..k + 4);
-        match (a, b)
-        {
+        match (a, b) {
             (Num(a), Num(b)) => Ok(Num(functions(a, Some(b), to_deg.clone(), s, deg)?)),
-            (Vector(a), Vector(b)) if a.len() == b.len() =>
-            {
-                for i in 0..b.len()
-                {
+            (Vector(a), Vector(b)) if a.len() == b.len() => {
+                for i in 0..b.len() {
                     vec.push(functions(
                         a[i].clone(),
                         Some(b[i].clone()),
@@ -897,14 +690,11 @@ fn do_functions(
                 }
                 Ok(Vector(vec))
             }
-            (Matrix(a), Matrix(b)) if a.len() == b.len() && a[0].len() == b[0].len() =>
-            {
+            (Matrix(a), Matrix(b)) if a.len() == b.len() && a[0].len() == b[0].len() => {
                 let mut mat = Vec::new();
-                for i in 0..a.len()
-                {
+                for i in 0..a.len() {
                     vec.clear();
-                    for j in 0..a[0].len()
-                    {
+                    for j in 0..a[0].len() {
                         vec.push(functions(
                             a[i][j].clone(),
                             Some(b[i][j].clone()),
@@ -917,58 +707,45 @@ fn do_functions(
                 }
                 Ok(Matrix(mat))
             }
-            (Num(a), Vector(b)) =>
-            {
-                for i in b
-                {
+            (Num(a), Vector(b)) => {
+                for i in b {
                     vec.push(functions(a.clone(), Some(i), to_deg.clone(), s, deg)?)
                 }
                 Ok(Vector(vec))
             }
-            (Vector(a), Num(b)) =>
-            {
-                for i in a
-                {
+            (Vector(a), Num(b)) => {
+                for i in a {
                     vec.push(functions(i, Some(b.clone()), to_deg.clone(), s, deg)?)
                 }
                 Ok(Vector(vec))
             }
-            (Num(a), Matrix(b)) =>
-            {
+            (Num(a), Matrix(b)) => {
                 let mut mat = Vec::new();
-                for i in b
-                {
+                for i in b {
                     vec.clear();
-                    for j in i
-                    {
+                    for j in i {
                         vec.push(functions(a.clone(), Some(j), to_deg.clone(), s, deg)?)
                     }
                     mat.push(vec.clone());
                 }
                 Ok(Matrix(mat))
             }
-            (Matrix(a), Num(b)) =>
-            {
+            (Matrix(a), Num(b)) => {
                 let mut mat = Vec::new();
-                for i in a
-                {
+                for i in a {
                     vec.clear();
-                    for j in i
-                    {
+                    for j in i {
                         vec.push(functions(j, Some(b.clone()), to_deg.clone(), s, deg)?)
                     }
                     mat.push(vec.clone());
                 }
                 Ok(Matrix(mat))
             }
-            (Matrix(a), Vector(b)) if a.len() == b.len() =>
-            {
+            (Matrix(a), Vector(b)) if a.len() == b.len() => {
                 let mut mat = Vec::new();
-                for i in 0..a.len()
-                {
+                for i in 0..a.len() {
                     vec.clear();
-                    for j in 0..a[0].len()
-                    {
+                    for j in 0..a[0].len() {
                         vec.push(functions(
                             a[i][j].clone(),
                             Some(b[i].clone()),
@@ -981,14 +758,11 @@ fn do_functions(
                 }
                 Ok(Matrix(mat))
             }
-            (Vector(a), Matrix(b)) if a.len() == b.len() =>
-            {
+            (Vector(a), Matrix(b)) if a.len() == b.len() => {
                 let mut mat = Vec::new();
-                for i in 0..b.len()
-                {
+                for i in 0..b.len() {
                     vec.clear();
-                    for j in 0..b[0].len()
-                    {
+                    for j in 0..b[0].len() {
                         vec.push(functions(
                             a[i].clone(),
                             Some(b[i][j].clone()),
@@ -1003,29 +777,21 @@ fn do_functions(
             }
             _ => Err("unhreachable"),
         }
-    }
-    else
-    {
-        match a
-        {
-            Matrix(a) =>
-            {
+    } else {
+        match a {
+            Matrix(a) => {
                 let mut mat = Vec::new();
-                for i in a
-                {
+                for i in a {
                     vec.clear();
-                    for j in i
-                    {
+                    for j in i {
                         vec.push(functions(j, None, to_deg.clone(), s, deg)?)
                     }
                     mat.push(vec.clone());
                 }
                 Ok(Matrix(mat))
             }
-            Vector(a) =>
-            {
-                for i in a
-                {
+            Vector(a) => {
+                for i in a {
                     vec.push(functions(i, None, to_deg.clone(), s, deg)?)
                 }
                 Ok(Vector(vec))
@@ -1035,42 +801,28 @@ fn do_functions(
         }
     }
 }
-pub fn to_polar(a: Vec<Complex>, to_deg: Complex) -> Vec<Complex>
-{
+pub fn to_polar(a: Vec<Complex>, to_deg: Complex) -> Vec<Complex> {
     let mut a = a;
-    if a.len() == 1
-    {
+    if a.len() == 1 {
         a.push(Complex::new(a[0].prec()));
     }
-    if a.len() != 2 && a.len() != 3
-    {
+    if a.len() != 2 && a.len() != 3 {
         vec![]
-    }
-    else if a.len() == 2
-    {
-        if a[1].eq0()
-        {
-            if a[0].eq0()
-            {
+    } else if a.len() == 2 {
+        if a[1].eq0() {
+            if a[0].eq0() {
                 vec![Complex::new(a[0].prec()), Complex::new(a[0].prec())]
-            }
-            else
-            {
+            } else {
                 vec![
                     a[0].clone().abs(),
-                    if a[0].real().is_sign_positive()
-                    {
+                    if a[0].real().is_sign_positive() {
                         Complex::with_val(a[0].prec(), 0)
-                    }
-                    else
-                    {
+                    } else {
                         to_deg * Complex::with_val(a[0].prec(), Pi)
                     },
                 ]
             }
-        }
-        else
-        {
+        } else {
             let mut n: Complex = a[0].clone().pow(2) + a[1].clone().pow(2);
             n = n.sqrt();
             vec![
@@ -1078,30 +830,22 @@ pub fn to_polar(a: Vec<Complex>, to_deg: Complex) -> Vec<Complex>
                 a[1].clone() / a[1].clone().abs() * (&a[0] / n).acos() * to_deg,
             ]
         }
-    }
-    else if a[1].eq0()
-    {
-        if a[0].eq0()
-        {
-            if a[2].eq0()
-            {
+    } else if a[1].eq0() {
+        if a[0].eq0() {
+            if a[2].eq0() {
                 vec![
                     Complex::with_val(a[0].prec(), 0),
                     Complex::with_val(a[0].prec(), 0),
                     Complex::with_val(a[0].prec(), 0),
                 ]
-            }
-            else
-            {
+            } else {
                 vec![
                     a[2].clone().abs(),
                     Complex::with_val(a[0].prec(), 0),
                     Complex::with_val(a[0].prec(), 0),
                 ]
             }
-        }
-        else
-        {
+        } else {
             let mut n: Complex = a[0].clone().pow(2) + a[1].clone().pow(2) + a[2].clone().pow(2);
             n = n.sqrt();
             vec![
@@ -1110,9 +854,7 @@ pub fn to_polar(a: Vec<Complex>, to_deg: Complex) -> Vec<Complex>
                 Complex::with_val(a[0].prec(), 0),
             ]
         }
-    }
-    else
-    {
+    } else {
         let mut n: Complex = a[0].clone().pow(2) + a[1].clone().pow(2) + a[2].clone().pow(2);
         n = n.sqrt();
         let t: Complex = a[0].clone().pow(2) + a[1].clone().pow(2);
@@ -1123,21 +865,17 @@ pub fn to_polar(a: Vec<Complex>, to_deg: Complex) -> Vec<Complex>
         ]
     }
 }
-fn subfact(a: f64) -> f64
-{
-    if a == 0.0
-    {
+fn subfact(a: f64) -> f64 {
+    if a == 0.0 {
         return 1.0;
     }
-    if a.fract() != 0.0
-    {
+    if a.fract() != 0.0 {
         return f64::NAN;
     }
     let mut prev = 1.0;
     let mut curr = 0.0;
     let mut next;
-    for i in 2..=(a as usize)
-    {
+    for i in 2..=(a as usize) {
         next = (i - 1) as f64 * (prev + curr);
         prev = curr;
         curr = next;
@@ -1152,42 +890,32 @@ fn sum(
     product: bool,
     deg: AngleType,
     prec: u32,
-) -> Result<NumStr, &'static str>
-{
+) -> Result<NumStr, &'static str> {
     let mut func = function.clone();
     let mut math;
-    for k in func.iter_mut()
-    {
-        if k.str_is(var)
-        {
+    for k in func.iter_mut() {
+        if k.str_is(var) {
             *k = Num(Complex::with_val(prec, start));
         }
     }
     let mut value = do_math(func, deg, prec)?;
-    for z in start + 1..=end
-    {
+    for z in start + 1..=end {
         func = function.clone();
-        for k in func.iter_mut()
-        {
-            if k.str_is(var)
-            {
+        for k in func.iter_mut() {
+            if k.str_is(var) {
                 *k = Num(Complex::with_val(prec, z));
             }
         }
         math = do_math(func, deg, prec)?;
-        if !product
-        {
+        if !product {
             value = value.add(&math)?;
-        }
-        else
-        {
+        } else {
             value = value.mul(&math)?;
         }
     }
     Ok(value)
 }
-fn submatrix(a: Vec<Vec<Complex>>, row: usize, col: usize) -> Vec<Vec<Complex>>
-{
+fn submatrix(a: Vec<Vec<Complex>>, row: usize, col: usize) -> Vec<Vec<Complex>> {
     a.iter()
         .enumerate()
         .filter(|&(i, _)| i != row)
@@ -1200,32 +928,22 @@ fn submatrix(a: Vec<Vec<Complex>>, row: usize, col: usize) -> Vec<Vec<Complex>>
         })
         .collect()
 }
-fn determinant(a: Vec<Vec<Complex>>) -> Complex
-{
-    if a.len() == 1
-    {
+fn determinant(a: Vec<Vec<Complex>>) -> Complex {
+    if a.len() == 1 {
         a[0][0].clone()
-    }
-    else if a.len() == 2
-    {
+    } else if a.len() == 2 {
         a[0][0].clone() * a[1][1].clone() - a[1][0].clone() * a[0][1].clone()
-    }
-    else if a.len() == 3
-    {
+    } else if a.len() == 3 {
         a[0][0].clone() * (a[1][1].clone() * a[2][2].clone() - a[1][2].clone() * a[2][1].clone())
             + a[0][1].clone()
                 * (a[1][2].clone() * a[2][0].clone() - a[1][0].clone() * a[2][2].clone())
             + a[0][2].clone()
                 * (a[1][0].clone() * a[2][1].clone() - a[1][1].clone() * a[2][0].clone())
-    }
-    else
-    {
+    } else {
         let mut det = Complex::new(a[0][0].prec());
-        for (i, x) in a[0].iter().enumerate()
-        {
+        for (i, x) in a[0].iter().enumerate() {
             let mut sub_matrix = a[1..].to_vec();
-            for row in &mut sub_matrix
-            {
+            for row in &mut sub_matrix {
                 row.remove(i);
             }
             det += x * determinant(sub_matrix) * if i % 2 == 0 { 1.0 } else { -1.0 };
@@ -1233,59 +951,43 @@ fn determinant(a: Vec<Vec<Complex>>) -> Complex
         det
     }
 }
-fn transpose(a: Vec<Vec<Complex>>) -> Vec<Vec<Complex>>
-{
+fn transpose(a: Vec<Vec<Complex>>) -> Vec<Vec<Complex>> {
     let mut b = vec![vec![Complex::new(a[0][0].prec()); a.len()]; a[0].len()];
-    for (i, l) in a.iter().enumerate()
-    {
-        for (j, n) in l.iter().enumerate()
-        {
+    for (i, l) in a.iter().enumerate() {
+        for (j, n) in l.iter().enumerate() {
             b[j][i] = n.clone();
         }
     }
     b
 }
-fn minors(a: Vec<Vec<Complex>>) -> Vec<Vec<Complex>>
-{
+fn minors(a: Vec<Vec<Complex>>) -> Vec<Vec<Complex>> {
     let mut result = vec![vec![Complex::new(a[0][0].prec()); a[0].len()]; a.len()];
-    for (i, k) in result.iter_mut().enumerate()
-    {
-        for (j, l) in k.iter_mut().enumerate()
-        {
+    for (i, k) in result.iter_mut().enumerate() {
+        for (j, l) in k.iter_mut().enumerate() {
             *l = determinant(submatrix(a.clone(), i, j));
         }
     }
     result
 }
-fn cofactor(a: Vec<Vec<Complex>>) -> Vec<Vec<Complex>>
-{
+fn cofactor(a: Vec<Vec<Complex>>) -> Vec<Vec<Complex>> {
     let mut result = vec![vec![Complex::new(a[0][0].prec()); a[0].len()]; a.len()];
-    for (i, k) in result.iter_mut().enumerate()
-    {
-        for (j, l) in k.iter_mut().enumerate()
-        {
-            *l = if (i + j) % 2 == 1
-            {
+    for (i, k) in result.iter_mut().enumerate() {
+        for (j, l) in k.iter_mut().enumerate() {
+            *l = if (i + j) % 2 == 1 {
                 -determinant(submatrix(a.clone(), i, j))
-            }
-            else
-            {
+            } else {
                 determinant(submatrix(a.clone(), i, j))
             };
         }
     }
     result
 }
-pub fn inverse(a: Vec<Vec<Complex>>) -> Result<Vec<Vec<Complex>>, &'static str>
-{
-    if a.len() == a[0].len() && a.len() > 1
-    {
+pub fn inverse(a: Vec<Vec<Complex>>) -> Result<Vec<Vec<Complex>>, &'static str> {
+    if a.len() == a[0].len() && a.len() > 1 {
         Matrix(transpose(cofactor(a.clone())))
             .div(&Num(determinant(a)))?
             .mat()
-    }
-    else
-    {
+    } else {
         Err("not square")
     }
 }
@@ -1295,78 +997,56 @@ fn functions(
     to_deg: Complex,
     s: &str,
     deg: AngleType,
-) -> Result<Complex, &'static str>
-{
+) -> Result<Complex, &'static str> {
     let b;
     let prec = to_deg.prec();
-    Ok(match s
-    {
+    Ok(match s {
         "sin" => (a / to_deg.clone()).sin(),
         "csc" => (a / to_deg.clone()).sin().recip(),
         "cos" => (a / to_deg.clone()).cos(),
         "sec" => (a / to_deg.clone()).cos().recip(),
         "tan" => (a / to_deg.clone()).tan(),
         "cot" => (a / to_deg.clone()).tan().recip(),
-        "asin" | "arcsin" =>
-        {
+        "asin" | "arcsin" => {
             b = a.clone().asin() * to_deg.clone();
-            if a.imag() == &0.0 && a.real() >= &1.0
-            {
+            if a.imag() == &0.0 && a.real() >= &1.0 {
                 Complex::with_val(prec, (b.real(), -b.imag()))
-            }
-            else
-            {
+            } else {
                 b
             }
         }
-        "acsc" | "arccsc" =>
-        {
+        "acsc" | "arccsc" => {
             b = a.clone().recip().asin() * to_deg.clone();
-            if a.imag() == &0.0
-            {
+            if a.imag() == &0.0 {
                 Complex::with_val(prec, (b.real(), -b.imag()))
-            }
-            else
-            {
+            } else {
                 b
             }
         }
-        "acos" | "arccos" =>
-        {
+        "acos" | "arccos" => {
             b = a.clone().acos() * to_deg.clone();
-            if a.imag() == &0.0 && a.real() >= &1.0
-            {
+            if a.imag() == &0.0 && a.real() >= &1.0 {
                 Complex::with_val(prec, (b.real(), -b.imag()))
-            }
-            else
-            {
+            } else {
                 b
             }
         }
-        "asec" | "arcsec" =>
-        {
+        "asec" | "arcsec" => {
             b = a.clone().recip().acos() * to_deg.clone();
-            if a.imag() == &0.0
-            {
+            if a.imag() == &0.0 {
                 Complex::with_val(prec, (b.real(), -b.imag()))
-            }
-            else
-            {
+            } else {
                 b
             }
         }
-        "atan" | "arctan" | "atan2" =>
-        {
-            if let Some(b) = c
-            {
+        "atan" | "arctan" | "atan2" => {
+            if let Some(b) = c {
                 let i = Complex::with_val(prec, (0, 1));
                 ((a.clone() + b.clone() * i.clone()) / (a.clone() + b.clone() * i.clone()).abs())
                     .ln()
                     * -i
                     * to_deg.clone()
-            }
-            else
-            {
+            } else {
                 a.atan() * to_deg.clone()
             }
         }
@@ -1380,55 +1060,38 @@ fn functions(
         "asinh" | "arcsinh" => a.asinh(),
         "acsch" | "arccsch" => a.recip().asinh(),
         "acosh" | "arccosh" => a.acosh(),
-        "asech" | "arcsech" =>
-        {
+        "asech" | "arcsech" => {
             b = a.clone().recip().acosh();
-            if a.imag() == &0.0 && a.real() < &0.0
-            {
+            if a.imag() == &0.0 && a.real() < &0.0 {
                 Complex::with_val(prec, (b.real(), -b.imag()))
-            }
-            else
-            {
+            } else {
                 b
             }
         }
-        "atanh" | "arctanh" =>
-        {
+        "atanh" | "arctanh" => {
             b = a.clone().atanh();
-            if a.imag() == &0.0 && a.real() >= &1.0
-            {
+            if a.imag() == &0.0 && a.real() >= &1.0 {
                 Complex::with_val(prec, (b.real(), -b.imag()))
-            }
-            else
-            {
+            } else {
                 b
             }
         }
-        "acoth" | "arccoth" =>
-        {
+        "acoth" | "arccoth" => {
             b = a.clone().recip().atanh();
-            if a.imag() == &0.0
-            {
+            if a.imag() == &0.0 {
                 Complex::with_val(prec, (b.real(), -b.imag()))
-            }
-            else
-            {
+            } else {
                 b
             }
         }
-        "cis" =>
-        {
+        "cis" => {
             (a.clone() / to_deg.clone()).cos()
                 + (a / to_deg.clone()).sin() * Complex::with_val(prec, (0.0, 1.0))
         }
-        "ln" | "aexp" =>
-        {
-            if a.imag() == &0.0
-            {
+        "ln" | "aexp" => {
+            if a.imag() == &0.0 {
                 Complex::with_val(prec, a.real()).ln()
-            }
-            else
-            {
+            } else {
                 a.ln()
             }
         }
@@ -1437,37 +1100,25 @@ fn functions(
         "round" => Complex::with_val(prec, (a.real().clone().round(), a.imag().clone().round())),
         "recip" => a.recip(),
         "exp" | "aln" => a.exp(),
-        "log" =>
-        {
-            let a = if a.imag() == &0.0
-            {
+        "log" => {
+            let a = if a.imag() == &0.0 {
                 Complex::with_val(prec, a.real()).ln()
-            }
-            else
-            {
+            } else {
                 a.ln()
             };
-            if let Some(b) = c
-            {
-                let b = if b.imag() == &0.0
-                {
+            if let Some(b) = c {
+                let b = if b.imag() == &0.0 {
                     Complex::with_val(prec, b.real()).ln()
-                }
-                else
-                {
+                } else {
                     b.ln()
                 };
                 b / a
-            }
-            else
-            {
+            } else {
                 a
             }
         }
-        "root" =>
-        {
-            if let Some(b) = c
-            {
+        "root" => {
+            if let Some(b) = c {
                 match b.imag() == &0.0
                     && (b.real().to_f64() / 2.0).fract() != 0.0
                     && &b.real().clone().trunc() == b.real()
@@ -1480,22 +1131,15 @@ fn functions(
                     ),
                     false => a.pow(b.recip()),
                 }
-            }
-            else
-            {
+            } else {
                 a.sqrt()
             }
         }
-        "bi" | "binomial" =>
-        {
-            if let Some(b) = c
-            {
-                if a.imag() != &0.0 && b.imag() != &0.0
-                {
+        "bi" | "binomial" => {
+            if let Some(b) = c {
+                if a.imag() != &0.0 && b.imag() != &0.0 {
                     return Err("binomial complex not supported");
-                }
-                else if a.real().clone().fract() == 0.0 && b.real().clone().fract() == 0.0
-                {
+                } else if a.real().clone().fract() == 0.0 && b.real().clone().fract() == 0.0 {
                     Complex::with_val(
                         prec,
                         a.real()
@@ -1503,109 +1147,78 @@ fn functions(
                             .unwrap()
                             .binomial(b.real().to_f64() as u32),
                     )
-                }
-                else
-                {
+                } else {
                     let c: Float = a.real().clone() + 1;
                     let d: Float = b.real().clone() + 1;
                     let e: Float = a.real().clone() - b.real().clone() + 1;
                     Complex::with_val(prec, c.gamma() / (d.gamma() * e.gamma()))
                 }
-            }
-            else
-            {
+            } else {
                 return Err("no args");
             }
         }
-        "gamma" | "Γ" =>
-        {
-            if a.imag() == &0.0
-            {
+        "gamma" | "Γ" => {
+            if a.imag() == &0.0 {
                 Complex::with_val(prec, a.real().clone().gamma())
-            }
-            else
-            {
+            } else {
                 return Err("complex gamma not supported");
             }
         }
-        "max" =>
-        {
-            if let Some(b) = c
-            {
+        "max" => {
+            if let Some(b) = c {
                 Complex::with_val(
                     prec,
                     (
-                        if a.real() > b.real()
-                        {
+                        if a.real() > b.real() {
                             a.real()
-                        }
-                        else
-                        {
+                        } else {
                             b.real()
                         },
-                        if a.imag() > b.imag()
-                        {
+                        if a.imag() > b.imag() {
                             a.imag()
-                        }
-                        else
-                        {
+                        } else {
                             b.imag()
                         },
                     ),
                 )
-            }
-            else
-            {
+            } else {
                 return Err("no args");
             }
         }
-        "min" =>
-        {
-            if let Some(b) = c
-            {
+        "min" => {
+            if let Some(b) = c {
                 Complex::with_val(
                     prec,
                     (
-                        if a.real() < b.real()
-                        {
+                        if a.real() < b.real() {
                             a.real()
-                        }
-                        else
-                        {
+                        } else {
                             b.real()
                         },
-                        if a.imag() < b.imag()
-                        {
+                        if a.imag() < b.imag() {
                             a.imag()
-                        }
-                        else
-                        {
+                        } else {
                             b.imag()
                         },
                     ),
                 )
-            }
-            else
-            {
+            } else {
                 return Err("no args");
             }
         }
         "sqrt" | "asquare" => a.sqrt(),
         "abs" | "norm" => a.abs(),
-        "deg" | "degree" => match deg
-        {
+        "deg" | "degree" => match deg {
             Radians => a * Complex::with_val(prec, 180) / Complex::with_val(prec, Pi),
             Gradians => a * 180.0 / 200.0,
             Degrees => a,
         },
-        "rad" | "radian" => match deg
-        {
+        "rad" | "radian" => match deg {
             Radians => a,
             Gradians => a * Complex::with_val(prec, Pi) / Complex::with_val(prec, 200),
             Degrees => a * Complex::with_val(prec, Pi) / Complex::with_val(prec, 180),
         },
-        "grad" | "gradian" => match deg
-        {
+        "grad" | "gradian" => match deg {
             Radians => a * Complex::with_val(prec, 200) / Complex::with_val(prec, Pi),
             Gradians => a,
             Degrees => a * 200.0 / 180.0,
@@ -1614,117 +1227,81 @@ fn functions(
         "im" | "imag" => Complex::with_val(prec, a.imag()),
         "sgn" | "sign" => Complex::with_val(prec, a.clone() / a.abs()),
         "arg" => a.arg(),
-        "cbrt" | "acube" =>
-        {
-            if a.imag() == &0.0
-            {
-                if a.real() == &0.0
-                {
+        "cbrt" | "acube" => {
+            if a.imag() == &0.0 {
+                if a.real() == &0.0 {
                     Complex::new(prec)
-                }
-                else
-                {
+                } else {
                     Complex::with_val(
                         prec,
                         a.real() / a.real().clone().abs()
                             * a.real().clone().abs().pow(3f64.recip()),
                     )
                 }
-            }
-            else
-            {
+            } else {
                 a.pow(3f64.recip())
             }
         }
-        "frac" | "fract" =>
-        {
+        "frac" | "fract" => {
             Complex::with_val(prec, (a.real().clone().fract(), a.imag().clone().fract()))
         }
-        "int" | "trunc" =>
-        {
+        "int" | "trunc" => {
             Complex::with_val(prec, (a.real().clone().trunc(), a.imag().clone().trunc()))
         }
         "square" | "asqrt" => a.pow(2),
         "cube" | "acbrt" => a.pow(3),
-        "fact" =>
-        {
-            if a.imag() == &0.0
-            {
+        "fact" => {
+            if a.imag() == &0.0 {
                 let b: Float = a.real().clone() + 1;
                 Complex::with_val(prec, b.gamma())
-            }
-            else
-            {
+            } else {
                 return Err("complex factorial not supported");
             }
         }
-        "subfact" =>
-        {
-            if a.imag() != &0.0 || a.real() < &0.0
-            {
+        "subfact" => {
+            if a.imag() != &0.0 || a.real() < &0.0 {
                 return Err("complex/fractional subfactorial not supported");
             }
             Complex::with_val(prec, subfact(a.real().to_f64()))
         }
         "sinc" => a.clone().sin() / a,
         "conj" | "conjugate" => a.conj(),
-        "erf" =>
-        {
-            if a.imag() == &0.0
-            {
+        "erf" => {
+            if a.imag() == &0.0 {
                 Complex::with_val(prec, a.real().clone().erf())
-            }
-            else
-            {
+            } else {
                 return Err("complex erf not supported");
             }
         }
-        "erfc" =>
-        {
-            if a.imag() == &0.0
-            {
+        "erfc" => {
+            if a.imag() == &0.0 {
                 Complex::with_val(prec, a.real().clone().erfc())
-            }
-            else
-            {
+            } else {
                 return Err("complex erfc not supported");
             }
         }
-        "ai" =>
-        {
-            if a.imag() == &0.0
-            {
+        "ai" => {
+            if a.imag() == &0.0 {
                 Complex::with_val(prec, a.real().clone().ai())
-            }
-            else
-            {
+            } else {
                 return Err("complex ai not supported");
             }
         }
-        "digamma" =>
-        {
-            if a.imag() == &0.0
-            {
+        "digamma" => {
+            if a.imag() == &0.0 {
                 Complex::with_val(prec, a.real().clone().digamma())
-            }
-            else
-            {
+            } else {
                 return Err("complex digamma not supported");
             }
         }
-        "zeta" | "ζ" =>
-        {
-            if a.imag() == &0.0
-            {
+        "zeta" | "ζ" => {
+            if a.imag() == &0.0 {
                 Complex::with_val(prec, a.real().clone().zeta())
-            }
-            else
-            {
+            } else {
                 return Err("complex zeta not supported");
             }
         }
-        _ =>
-        {
+        _ => {
             return Err("unreachable7");
         }
     })

--- a/src/options.rs
+++ b/src/options.rs
@@ -7,27 +7,22 @@ use std::{
     fs::File,
     io::{BufRead, BufReader},
 };
-pub fn arg_opts(options: &mut Options, args: &mut Vec<String>) -> bool
-{
+pub fn arg_opts(options: &mut Options, args: &mut Vec<String>) -> bool {
     let mut err = false;
     args.remove(0);
     let (mut split, mut l);
     let mut i = 0;
-    while i < args.len()
-    {
-        if args[i].starts_with("--") && (args[i].contains('=') || args[i].contains(','))
-        {
+    while i < args.len() {
+        if args[i].starts_with("--") && (args[i].contains('=') || args[i].contains(',')) {
             l = args[i].clone();
             split = l.split(|c| c == '=' || c == ',');
             args[i] = split.next().unwrap().to_string();
             args.insert(i + 1, split.next().unwrap().to_string());
-            if split.clone().count() > 0
-            {
+            if split.clone().count() > 0 {
                 args.insert(i + 2, split.next().unwrap().to_string());
             }
         }
-        match args[i].as_str()
-        {
+        match args[i].as_str() {
             "--debug" => options.debug = !options.debug,
             "--tau" => options.tau = !options.tau,
             "--small_e" => options.small_e = !options.small_e,
@@ -42,28 +37,20 @@ pub fn arg_opts(options: &mut Options, args: &mut Vec<String>) -> bool
             "--frac" => options.frac = !options.frac,
             "--multi" => options.multi = !options.multi,
             "--tabbed" => options.tabbed = !options.tabbed,
-            "--prec" | "--precision" =>
-            {
-                if args.len() > 1
-                {
-                    options.prec = match args[i + 1].parse::<u32>()
-                    {
-                        Ok(x) =>
-                        {
-                            if x == 0
-                            {
+            "--prec" | "--precision" => {
+                if args.len() > 1 {
+                    options.prec = match args[i + 1].parse::<u32>() {
+                        Ok(x) => {
+                            if x == 0 {
                                 println!("Invalid precision");
                                 err = true;
                                 args.remove(i);
                                 continue;
-                            }
-                            else
-                            {
+                            } else {
                                 x
                             }
                         }
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid precision");
                             err = true;
                             args.remove(i);
@@ -73,25 +60,16 @@ pub fn arg_opts(options: &mut Options, args: &mut Vec<String>) -> bool
                     args.remove(i);
                 }
             }
-            "--decimal" | "--deci" | "--decimals" =>
-            {
-                if args.len() > 1
-                {
-                    if args[i + 1] == "-1"
-                    {
+            "--decimal" | "--deci" | "--decimals" => {
+                if args.len() > 1 {
+                    if args[i + 1] == "-1" {
                         options.decimal_places = usize::MAX - 1;
-                    }
-                    else if args[i + 1] == "-2"
-                    {
+                    } else if args[i + 1] == "-2" {
                         options.decimal_places = usize::MAX;
-                    }
-                    else
-                    {
-                        options.decimal_places = match args[i + 1].parse::<usize>()
-                        {
+                    } else {
+                        options.decimal_places = match args[i + 1].parse::<usize>() {
                             Ok(x) => x,
-                            Err(_) =>
-                            {
+                            Err(_) => {
                                 println!("Invalid decimal");
                                 err = true;
                                 args.remove(i);
@@ -102,15 +80,11 @@ pub fn arg_opts(options: &mut Options, args: &mut Vec<String>) -> bool
                     args.remove(i);
                 }
             }
-            "--frac_iter" =>
-            {
-                if args.len() > 1
-                {
-                    options.frac_iter = match args[i + 1].parse::<usize>()
-                    {
+            "--frac_iter" => {
+                if args.len() > 1 {
+                    options.frac_iter = match args[i + 1].parse::<usize>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid frac iter");
                             err = true;
                             args.remove(i);
@@ -120,15 +94,11 @@ pub fn arg_opts(options: &mut Options, args: &mut Vec<String>) -> bool
                     args.remove(i);
                 }
             }
-            "--2d" =>
-            {
-                if args.len() > 1
-                {
-                    options.samples_2d = match args[i + 1].parse::<f64>()
-                    {
+            "--2d" => {
+                if args.len() > 1 {
+                    options.samples_2d = match args[i + 1].parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid 2d sample size");
                             err = true;
                             args.remove(i);
@@ -138,15 +108,11 @@ pub fn arg_opts(options: &mut Options, args: &mut Vec<String>) -> bool
                     args.remove(i);
                 }
             }
-            "--3d" =>
-            {
-                if args.len() > 1
-                {
-                    options.samples_3d = match args[i + 1].parse::<f64>()
-                    {
+            "--3d" => {
+                if args.len() > 1 {
+                    options.samples_3d = match args[i + 1].parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid 3d sample size");
                             err = true;
                             args.remove(i);
@@ -156,26 +122,20 @@ pub fn arg_opts(options: &mut Options, args: &mut Vec<String>) -> bool
                     args.remove(i);
                 }
             }
-            "--yr" =>
-            {
-                if args.len() > 2
-                {
-                    options.yr[0] = match args[i + 1].parse::<f64>()
-                    {
+            "--yr" => {
+                if args.len() > 2 {
+                    options.yr[0] = match args[i + 1].parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid y range");
                             err = true;
                             args.remove(i);
                             continue;
                         }
                     };
-                    options.yr[1] = match args[i + 2].parse::<f64>()
-                    {
+                    options.yr[1] = match args[i + 2].parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid y range");
                             err = true;
                             args.remove(i);
@@ -186,26 +146,20 @@ pub fn arg_opts(options: &mut Options, args: &mut Vec<String>) -> bool
                     args.remove(i);
                 }
             }
-            "--xr" =>
-            {
-                if args.len() > 2
-                {
-                    options.xr[0] = match args[i + 1].parse::<f64>()
-                    {
+            "--xr" => {
+                if args.len() > 2 {
+                    options.xr[0] = match args[i + 1].parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid x range");
                             err = true;
                             args.remove(i);
                             continue;
                         }
                     };
-                    options.xr[1] = match args[i + 2].parse::<f64>()
-                    {
+                    options.xr[1] = match args[i + 2].parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid x range");
                             err = true;
                             args.remove(i);
@@ -216,26 +170,20 @@ pub fn arg_opts(options: &mut Options, args: &mut Vec<String>) -> bool
                     args.remove(i);
                 }
             }
-            "--zr" =>
-            {
-                if args.len() > 2
-                {
-                    options.zr[0] = match args[i + 1].parse::<f64>()
-                    {
+            "--zr" => {
+                if args.len() > 2 {
+                    options.zr[0] = match args[i + 1].parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid z range");
                             err = true;
                             args.remove(i);
                             continue;
                         }
                     };
-                    options.zr[1] = match args[i + 2].parse::<f64>()
-                    {
+                    options.zr[1] = match args[i + 2].parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid z range");
                             err = true;
                             args.remove(i);
@@ -246,28 +194,20 @@ pub fn arg_opts(options: &mut Options, args: &mut Vec<String>) -> bool
                     args.remove(i);
                 }
             }
-            "--base" =>
-            {
-                if args.len() > 1
-                {
-                    options.base = match args[i + 1].parse::<usize>()
-                    {
-                        Ok(x) =>
-                        {
-                            if !(2..=36).contains(&x)
-                            {
+            "--base" => {
+                if args.len() > 1 {
+                    options.base = match args[i + 1].parse::<usize>() {
+                        Ok(x) => {
+                            if !(2..=36).contains(&x) {
                                 println!("Invalid base");
                                 err = true;
                                 args.remove(i);
                                 continue;
-                            }
-                            else
-                            {
+                            } else {
                                 x
                             }
                         }
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid base");
                             err = true;
                             args.remove(i);
@@ -279,12 +219,9 @@ pub fn arg_opts(options: &mut Options, args: &mut Vec<String>) -> bool
             }
             "--comma" => options.comma = !options.comma,
             "--sci" | "--scientific" => options.sci = !options.sci,
-            "--point" =>
-            {
-                options.point_style = match args[i + 1].chars().next()
-                {
-                    Some(x) =>
-                    {
+            "--point" => {
+                options.point_style = match args[i + 1].chars().next() {
+                    Some(x) => {
                         if x == '.'
                             || x == '+'
                             || x == 'x'
@@ -301,17 +238,14 @@ pub fn arg_opts(options: &mut Options, args: &mut Vec<String>) -> bool
                             || x == 'R'
                         {
                             x
-                        }
-                        else
-                        {
+                        } else {
                             println!("Invalid point char");
                             err = true;
                             args.remove(i);
                             continue;
                         }
                     }
-                    None =>
-                    {
+                    None => {
                         println!("Invalid point char");
                         err = true;
                         args.remove(i);
@@ -320,23 +254,19 @@ pub fn arg_opts(options: &mut Options, args: &mut Vec<String>) -> bool
                 };
                 args.remove(i);
             }
-            "--help" | "-h" =>
-            {
+            "--help" | "-h" => {
                 help();
                 std::process::exit(0);
             }
-            "--version" | "-v" =>
-            {
+            "--version" | "-v" => {
                 println!("{} v{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
                 std::process::exit(0);
             }
             "--vars" => options.allow_vars = !options.allow_vars,
-            "--default" | "--def" =>
-            {
+            "--default" | "--def" => {
                 *options = Options::default();
             }
-            _ =>
-            {
+            _ => {
                 i += 1;
                 continue;
             }
@@ -345,191 +275,145 @@ pub fn arg_opts(options: &mut Options, args: &mut Vec<String>) -> bool
     }
     err
 }
-pub fn file_opts(options: &mut Options, file_path: &String) -> bool
-{
+pub fn file_opts(options: &mut Options, file_path: &String) -> bool {
     let mut err = false;
-    if File::open(file_path).is_ok()
-    {
+    if File::open(file_path).is_ok() {
         let file = File::open(file_path).unwrap();
         let reader = BufReader::new(file);
         let mut split;
-        for line in reader.lines().map(|l| l.unwrap())
-        {
+        for line in reader.lines().map(|l| l.unwrap()) {
             split = line.split('=');
-            match split.next().unwrap()
-            {
-                "frac_iter" =>
-                {
-                    options.frac_iter = match split.next().unwrap().parse::<usize>()
-                    {
+            match split.next().unwrap() {
+                "frac_iter" => {
+                    options.frac_iter = match split.next().unwrap().parse::<usize>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid frac iter");
                             err = true;
                             continue;
                         }
                     }
                 }
-                "2d" =>
-                {
-                    options.samples_2d = match split.next().unwrap().parse::<f64>()
-                    {
+                "2d" => {
+                    options.samples_2d = match split.next().unwrap().parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid 2d sample size");
                             err = true;
                             continue;
                         }
                     }
                 }
-                "3d" =>
-                {
-                    options.samples_3d = match split.next().unwrap().parse::<f64>()
-                    {
+                "3d" => {
+                    options.samples_3d = match split.next().unwrap().parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid 3d sample size");
                             err = true;
                             continue;
                         }
                     }
                 }
-                "xr" =>
-                {
+                "xr" => {
                     let mut xr = split.next().unwrap().split(',');
-                    if xr.clone().count() != 2
-                    {
+                    if xr.clone().count() != 2 {
                         println!("Invalid x range");
                         err = true;
                         continue;
                     }
-                    options.xr[0] = match xr.next().unwrap().parse::<f64>()
-                    {
+                    options.xr[0] = match xr.next().unwrap().parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid x range");
                             err = true;
                             continue;
                         }
                     };
-                    options.xr[1] = match xr.next().unwrap().parse::<f64>()
-                    {
+                    options.xr[1] = match xr.next().unwrap().parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid x range");
                             err = true;
                             continue;
                         }
                     };
                 }
-                "yr" =>
-                {
+                "yr" => {
                     let mut yr = split.next().unwrap().split(',');
-                    if yr.clone().count() != 2
-                    {
+                    if yr.clone().count() != 2 {
                         println!("Invalid y range");
                         err = true;
                         continue;
                     }
-                    options.yr[0] = match yr.next().unwrap().parse::<f64>()
-                    {
+                    options.yr[0] = match yr.next().unwrap().parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid y range");
                             err = true;
                             continue;
                         }
                     };
-                    options.yr[1] = match yr.next().unwrap().parse::<f64>()
-                    {
+                    options.yr[1] = match yr.next().unwrap().parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid y range");
                             err = true;
                             continue;
                         }
                     };
                 }
-                "zr" =>
-                {
+                "zr" => {
                     let mut zr = split.next().unwrap().split(',');
-                    if zr.clone().count() != 2
-                    {
+                    if zr.clone().count() != 2 {
                         println!("Invalid z range");
                         err = true;
                         continue;
                     }
-                    options.zr[0] = match zr.next().unwrap().parse::<f64>()
-                    {
+                    options.zr[0] = match zr.next().unwrap().parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid z range");
                             err = true;
                             continue;
                         }
                     };
-                    options.zr[1] = match zr.next().unwrap().parse::<f64>()
-                    {
+                    options.zr[1] = match zr.next().unwrap().parse::<f64>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid z range");
                             err = true;
                             continue;
                         }
                     };
                 }
-                "prec" | "precision" =>
-                {
-                    options.prec = match split.next().unwrap().parse::<u32>()
-                    {
-                        Ok(x) =>
-                        {
-                            if x == 0
-                            {
+                "prec" | "precision" => {
+                    options.prec = match split.next().unwrap().parse::<u32>() {
+                        Ok(x) => {
+                            if x == 0 {
                                 println!("Invalid precision");
                                 err = true;
                                 continue;
-                            }
-                            else
-                            {
+                            } else {
                                 x
                             }
                         }
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid precision");
                             err = true;
                             continue;
                         }
                     };
                 }
-                "decimal" | "deci" | "decimals" =>
-                {
+                "decimal" | "deci" | "decimals" => {
                     let r = split.next().unwrap();
-                    if r == "-1"
-                    {
+                    if r == "-1" {
                         options.decimal_places = usize::MAX - 1;
-                    }
-                    else if r == "-2"
-                    {
+                    } else if r == "-2" {
                         options.decimal_places = usize::MAX;
-                    }
-                    else
-                    {
-                        options.decimal_places = match r.parse::<usize>()
-                        {
+                    } else {
+                        options.decimal_places = match r.parse::<usize>() {
                             Ok(x) => x,
-                            Err(_) =>
-                            {
+                            Err(_) => {
                                 println!("Invalid decimal places");
                                 err = true;
                                 continue;
@@ -537,142 +421,109 @@ pub fn file_opts(options: &mut Options, file_path: &String) -> bool
                         };
                     }
                 }
-                "multi" =>
-                {
-                    options.multi = match split.next().unwrap().parse::<bool>()
-                    {
+                "multi" => {
+                    options.multi = match split.next().unwrap().parse::<bool>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid multi bool");
                             err = true;
                             continue;
                         }
                     };
                 }
-                "small_e" =>
-                {
-                    options.small_e = match split.next().unwrap().parse::<bool>()
-                    {
+                "small_e" => {
+                    options.small_e = match split.next().unwrap().parse::<bool>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid small_e bool");
                             err = true;
                             continue;
                         }
                     };
                 }
-                "tabbed" =>
-                {
-                    options.tabbed = match split.next().unwrap().parse::<bool>()
-                    {
+                "tabbed" => {
+                    options.tabbed = match split.next().unwrap().parse::<bool>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid tabbed bool");
                             err = true;
                             continue;
                         }
                     };
                 }
-                "rt" =>
-                {
-                    options.real_time_output = match split.next().unwrap().parse::<bool>()
-                    {
+                "rt" => {
+                    options.real_time_output = match split.next().unwrap().parse::<bool>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid real time bool");
                             err = true;
                             continue;
                         }
                     };
                 }
-                "line" | "lines" =>
-                {
-                    options.lines = match split.next().unwrap().parse::<bool>()
-                    {
+                "line" | "lines" => {
+                    options.lines = match split.next().unwrap().parse::<bool>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid line bool");
                             err = true;
                             continue;
                         }
                     }
                 }
-                "polar" =>
-                {
-                    options.polar = match split.next().unwrap().parse::<bool>()
-                    {
+                "polar" => {
+                    options.polar = match split.next().unwrap().parse::<bool>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid polar bool");
                             err = true;
                             continue;
                         }
                     }
                 }
-                "frac" =>
-                {
-                    options.polar = match split.next().unwrap().parse::<bool>()
-                    {
+                "frac" => {
+                    options.polar = match split.next().unwrap().parse::<bool>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid frac bool");
                             err = true;
                             continue;
                         }
                     }
                 }
-                "prompt" =>
-                {
-                    options.prompt = match split.next().unwrap().parse::<bool>()
-                    {
+                "prompt" => {
+                    options.prompt = match split.next().unwrap().parse::<bool>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid prompt bool");
                             err = true;
                             continue;
                         }
                     }
                 }
-                "comma" =>
-                {
-                    options.comma = match split.next().unwrap().parse::<bool>()
-                    {
+                "comma" => {
+                    options.comma = match split.next().unwrap().parse::<bool>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid comma bool");
                             err = true;
                             continue;
                         }
                     }
                 }
-                "color" =>
-                {
-                    options.color = match split.next().unwrap().parse::<bool>()
-                    {
+                "color" => {
+                    options.color = match split.next().unwrap().parse::<bool>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid color bool");
                             err = true;
                             continue;
                         }
                     }
                 }
-                "point" =>
-                {
-                    options.point_style = match split.next().unwrap().chars().next()
-                    {
-                        Some(x) =>
-                        {
+                "point" => {
+                    options.point_style = match split.next().unwrap().chars().next() {
+                        Some(x) => {
                             if x == '.'
                                 || x == '+'
                                 || x == 'x'
@@ -689,67 +540,51 @@ pub fn file_opts(options: &mut Options, file_path: &String) -> bool
                                 || x == 'R'
                             {
                                 x
-                            }
-                            else
-                            {
+                            } else {
                                 println!("Invalid point char");
                                 err = true;
                                 continue;
                             }
                         }
-                        None =>
-                        {
+                        None => {
                             println!("Invalid point char");
                             err = true;
                             continue;
                         }
                     }
                 }
-                "sci" | "scientific" =>
-                {
-                    options.sci = match split.next().unwrap().parse::<bool>()
-                    {
+                "sci" | "scientific" => {
+                    options.sci = match split.next().unwrap().parse::<bool>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid scientific bool");
                             err = true;
                             continue;
                         }
                     }
                 }
-                "base" =>
-                {
-                    options.base = match split.next().unwrap().parse::<usize>()
-                    {
-                        Ok(x) =>
-                        {
-                            if !(2..=36).contains(&x)
-                            {
+                "base" => {
+                    options.base = match split.next().unwrap().parse::<usize>() {
+                        Ok(x) => {
+                            if !(2..=36).contains(&x) {
                                 println!("Invalid base");
                                 err = true;
                                 continue;
-                            }
-                            else
-                            {
+                            } else {
                                 x
                             }
                         }
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid base");
                             err = true;
                             continue;
                         }
                     };
                 }
-                "debug" =>
-                {
-                    options.debug = match split.next().unwrap().parse::<bool>()
-                    {
+                "debug" => {
+                    options.debug = match split.next().unwrap().parse::<bool>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid debug bool");
                             err = true;
                             continue;
@@ -759,34 +594,27 @@ pub fn file_opts(options: &mut Options, file_path: &String) -> bool
                 "deg" => options.deg = Radians,
                 "rad" => options.deg = Degrees,
                 "grad" => options.deg = Gradians,
-                "tau" =>
-                {
-                    options.tau = match split.next().unwrap().parse::<bool>()
-                    {
+                "tau" => {
+                    options.tau = match split.next().unwrap().parse::<bool>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid tau bool");
                             err = true;
                             continue;
                         }
                     }
                 }
-                "vars" =>
-                {
-                    options.allow_vars = match split.next().unwrap().parse::<bool>()
-                    {
+                "vars" => {
+                    options.allow_vars = match split.next().unwrap().parse::<bool>() {
                         Ok(x) => x,
-                        Err(_) =>
-                        {
+                        Err(_) => {
                             println!("Invalid vars bool");
                             err = true;
                             continue;
                         }
                     }
                 }
-                _ =>
-                {}
+                _ => {}
             }
         }
     }
@@ -794,8 +622,7 @@ pub fn file_opts(options: &mut Options, file_path: &String) -> bool
 }
 
 #[derive(Copy, Clone, PartialEq)]
-pub enum AngleType
-{
+pub enum AngleType {
     Radians,
     Degrees,
     Gradians,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -7,8 +7,7 @@ use crate::{
 };
 use rug::{ops::Pow, Complex};
 use std::collections::HashSet;
-pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static str>
-{
+pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static str> {
     let mut count: i32 = 0;
     let mut exp = String::new();
     let mut func: Vec<NumStr> = Vec::new();
@@ -18,16 +17,11 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
     let mut neg = false;
     let mut i = 1;
     let mut chars = input.chars().collect::<Vec<char>>();
-    while i < chars.len() - 1
-    {
-        if chars[i].is_whitespace()
-        {
-            if chars[i - 1].is_numeric() && chars[i + 1].is_numeric()
-            {
+    while i < chars.len() - 1 {
+        if chars[i].is_whitespace() {
+            if chars[i - 1].is_numeric() && chars[i + 1].is_numeric() {
                 chars[i] = '*'
-            }
-            else
-            {
+            } else {
                 chars.remove(i);
             }
         }
@@ -38,8 +32,7 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
     let n1 = Complex::with_val(options.prec, -1);
     let mut pow = String::new();
     let mut sum = 0;
-    'outer: while i < chars.len()
-    {
+    'outer: while i < chars.len() {
         c = chars[i];
         if !matches!(
             c,
@@ -68,8 +61,7 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
         {
             let i = pow.matches('i').count() % 4;
             pow = pow.replace('i', "");
-            if pow.is_empty()
-            {
+            if pow.is_empty() {
                 pow = "1".to_string();
             }
             if !func.is_empty()
@@ -79,8 +71,7 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
             }
             func.push(Num(Complex::with_val(
                 options.prec,
-                match Complex::parse(pow.as_bytes())
-                {
+                match Complex::parse(pow.as_bytes()) {
                     Ok(n) => n,
                     Err(_) => return Err("exponent error"),
                 },
@@ -88,17 +79,13 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
                 .pow(Complex::with_val(options.prec, i))));
             pow = String::new();
         }
-        if c.is_ascii_digit()
-        {
-            if !word.is_empty() && word != "0."
-            {
+        if c.is_ascii_digit() {
+            if !word.is_empty() && word != "0." {
                 find_word = false;
-                if is_func(&word) || sum != 0
-                {
+                if is_func(&word) || sum != 0 {
                     place_multiplier(&mut func, &find_word);
                     func.push(Str(word.clone()));
-                    if word == "sum" && sum == 0
-                    {
+                    if word == "sum" && sum == 0 {
                         sum = count + 1;
                     }
                 }
@@ -106,18 +93,13 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
             }
             place_multiplier(&mut func, &find_word);
             deci = false;
-            for c in chars[i..].iter()
-            {
-                match c
-                {
-                    '0'..='9' =>
-                    {
+            for c in chars[i..].iter() {
+                match c {
+                    '0'..='9' => {
                         word.push(*c);
                     }
-                    '.' =>
-                    {
-                        if deci
-                        {
+                    '.' => {
+                        if deci {
                             return Err("cant have multiple '.'");
                         }
                         deci = true;
@@ -127,15 +109,11 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
                 }
                 i += 1;
             }
-            if neg
-            {
-                if chars.len() > i && chars[i] == '^'
-                {
+            if neg {
+                if chars.len() > i && chars[i] == '^' {
                     func.push(Num(n1.clone()));
                     func.push(Str('*'.to_string()));
-                }
-                else
-                {
+                } else {
                     word.insert(0, '-');
                 }
                 neg = false;
@@ -146,26 +124,20 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
             )));
             word.clear();
             continue;
-        }
-        else if c.is_alphabetic()
-        {
+        } else if c.is_alphabetic() {
             if find_word
                 && (!(c == 'x' || c == 'y')
                     || (chars.len() - 1 != i && chars[i + 1] == 'p' && word == "e")
                     || word == "ma")
             {
                 word.push(c);
-            }
-            else
-            {
-                if neg
-                {
+            } else {
+                if neg {
                     func.push(Num(n1.clone()));
                     func.push(Str('*'.to_string()));
                     neg = false;
                 }
-                match c
-                {
+                match c {
                     'ⁱ' => pow.push('i'),
                     'E' | 'e'
                         if (options.small_e && c == 'e') || (!options.small_e && c == 'E') =>
@@ -185,17 +157,13 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
                             count += 1;
                         }
                     }
-                    'x' | 'y' =>
-                    {
-                        if !word.is_empty()
-                        {
+                    'x' | 'y' => {
+                        if !word.is_empty() {
                             find_word = false;
-                            if is_func(&word) || sum != 0
-                            {
+                            if is_func(&word) || sum != 0 {
                                 place_multiplier(&mut func, &find_word);
                                 func.push(Str(word.clone()));
-                                if word == "sum" && sum == 0
-                                {
+                                if word == "sum" && sum == 0 {
                                     sum = count + 1;
                                 }
                             }
@@ -204,31 +172,23 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
                         place_multiplier(&mut func, &find_word);
                         func.push(Str(c.to_string()));
                     }
-                    'i' =>
-                    {
-                        if i + 1 != chars.len() && (chars[i + 1] == 'n' || chars[i + 1] == 'm')
-                        {
+                    'i' => {
+                        if i + 1 != chars.len() && (chars[i + 1] == 'n' || chars[i + 1] == 'm') {
                             word.push(c);
                             find_word = true;
-                        }
-                        else
-                        {
+                        } else {
                             place_multiplier(&mut func, &find_word);
                             func.push(Num(Complex::with_val(options.prec, (0, 1))));
                         }
                     }
-                    _ =>
-                    {
+                    _ => {
                         word.push(c);
                         find_word = true;
                     }
                 }
             }
-        }
-        else
-        {
-            if !word.is_empty()
-            {
+        } else {
+            if !word.is_empty() {
                 find_word = false;
                 if i + 4 < chars.len()
                     && chars[i] == '^'
@@ -264,44 +224,37 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
                     func.push(Str(word.clone()));
                     word.clear();
                     let pos = chars.iter().skip(i + 1).position(|&c| c == '(' || c == ')');
-                    if pos.is_none()
-                    {
+                    if pos.is_none() {
                         continue;
                     }
                     exp = chars[i + 1..i + 1 + pos.unwrap()].iter().collect();
-                    if exp == "-"
-                    {
+                    if exp == "-" {
                         exp = "-1".to_string();
                     }
                     i += pos.unwrap() + 1;
                     continue;
                 }
-                if is_func(&word) || sum != 0
-                {
+                if is_func(&word) || sum != 0 {
                     place_multiplier(&mut func, &find_word);
                     func.push(Str(word.clone()));
-                    if word == "sum" && sum == 0
-                    {
+                    if word == "sum" && sum == 0 {
                         sum = count + 1;
                     }
                     word.clear();
                 }
             }
-            if !exp.is_empty() && c != '(' && c != ')'
-            {
+            if !exp.is_empty() && c != '(' && c != ')' {
                 func.push(Str("^".to_string()));
                 func.push(Num(Complex::with_val(
                     options.prec,
-                    match Complex::parse(exp.as_bytes())
-                    {
+                    match Complex::parse(exp.as_bytes()) {
                         Ok(n) => n,
                         Err(_) => return Err("exponent error"),
                     },
                 )));
                 exp = String::new();
             }
-            match c
-            {
+            match c {
                 '√' => func.push(Str("sqrt".to_string())),
                 '∛' => func.push(Str("cbrt".to_string())),
                 '¼' => func.push(Num(Complex::with_val(options.prec, 0.25))),
@@ -322,8 +275,7 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
                 '⅜' => func.push(Num(Complex::with_val(options.prec, 0.375))),
                 '⅝' => func.push(Num(Complex::with_val(options.prec, 0.625))),
                 '⅞' => func.push(Num(Complex::with_val(options.prec, 0.875))),
-                '⅟' =>
-                {
+                '⅟' => {
                     func.push(Num(Complex::with_val(options.prec, 1)));
                     func.push(Str("/".to_string()))
                 }
@@ -340,55 +292,40 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
                 '¹' | '₁' => pow.push('1'),
                 '⁻' => pow.push('-'),
                 '.' => word.push_str("0."),
-                '&' if i != 0 && i + 1 < chars.len() && chars[i + 1] == '&' =>
-                {
+                '&' if i != 0 && i + 1 < chars.len() && chars[i + 1] == '&' => {
                     func.push(Str("&&".to_string()));
                 }
-                '*' if i != 0 && i + 1 != chars.len() =>
-                {
-                    if i + 1 != chars.len() && chars[i + 1] == '*'
-                    {
+                '*' if i != 0 && i + 1 != chars.len() => {
+                    if i + 1 != chars.len() && chars[i + 1] == '*' {
                         func.push(Str("^".to_string()));
                         i += 1;
-                    }
-                    else
-                    {
+                    } else {
                         func.push(Str('*'.to_string()));
                     }
                 }
-                '=' if i != 0 && i + 1 < chars.len() =>
-                {
-                    if chars[i + 1] == '='
-                    {
+                '=' if i != 0 && i + 1 < chars.len() => {
+                    if chars[i + 1] == '=' {
                         func.push(Str("==".to_string()));
                         i += 1;
-                    }
-                    else if chars[i - 1] == '>'
-                    {
+                    } else if chars[i - 1] == '>' {
                         func.push(Str(">=".to_string()));
-                    }
-                    else if chars[i - 1] == '<'
-                    {
+                    } else if chars[i - 1] == '<' {
                         func.push(Str("<=".to_string()));
                     }
                 }
-                '{' =>
-                {
+                '{' => {
                     place_multiplier(&mut func, &find_word);
-                    if neg
-                    {
+                    if neg {
                         func.push(Num(n1.clone()));
                         func.push(Str('*'.to_string()));
                         neg = false;
                     }
                     func.push(Str("{".to_string()));
                 }
-                '}' =>
-                {
+                '}' => {
                     func.push(Str("}".to_string()));
                 }
-                '±' if i + 1 != chars.len() =>
-                {
+                '±' if i + 1 != chars.len() => {
                     if func.is_empty()
                         || matches!(func.last().unwrap(), Str(s) if !(s == ")" || s == "*"))
                     {
@@ -407,112 +344,82 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
                 {
                     func.push(Str('+'.to_string()))
                 }
-                '<' if i != 0 && i + 1 < chars.len() && chars[i + 1] != '=' =>
-                {
-                    if chars[i + 1] == '<'
-                    {
+                '<' if i != 0 && i + 1 < chars.len() && chars[i + 1] != '=' => {
+                    if chars[i + 1] == '<' {
                         func.push(Str("<<".to_string()));
                         i += 1;
-                    }
-                    else
-                    {
+                    } else {
                         func.push(Str('<'.to_string()));
                     }
                 }
-                '>' if i != 0 && i + 1 < chars.len() && chars[i + 1] != '=' =>
-                {
-                    if chars[i + 1] == '>'
-                    {
+                '>' if i != 0 && i + 1 < chars.len() && chars[i + 1] != '=' => {
+                    if chars[i + 1] == '>' {
                         func.push(Str(">>".to_string()));
                         i += 1;
-                    }
-                    else
-                    {
+                    } else {
                         func.push(Str('>'.to_string()));
                     }
                 }
-                '-' =>
-                {
-                    if i != 0 && chars[i - 1] == '^'
-                    {
+                '-' => {
+                    if i != 0 && chars[i - 1] == '^' {
                         func.push(Str("(".to_string()));
                         func.push(Num(n1.clone()));
                         count += 1;
-                    }
-                    else if i == 0
+                    } else if i == 0
                         || !(chars[i - 1] != if options.small_e { 'e' } else { 'E' }
                             && (chars[i - 1].is_alphanumeric()
                                 || func.last().unwrap().str_is(")")
                                 || chars[i - 1] == '}'
                                 || chars[i - 1] == ']'))
                     {
-                        if i + 1 != chars.len() && (chars[i + 1] == '(' || chars[i + 1] == '-')
-                        {
+                        if i + 1 != chars.len() && (chars[i + 1] == '(' || chars[i + 1] == '-') {
                             func.push(Num(n1.clone()));
                             func.push(Str("*".to_string()));
-                        }
-                        else
-                        {
+                        } else {
                             neg = true;
                         }
-                    }
-                    else
-                    {
+                    } else {
                         func.push(Str('-'.to_string()));
                     }
                 }
                 '^' if i != 0 && i + 1 != chars.len() => func.push(Str('^'.to_string())),
-                '(' if i + 1 != chars.len() && chars[i + 1] != ')' =>
-                {
+                '(' if i + 1 != chars.len() && chars[i + 1] != ')' => {
                     count += 1;
                     place_multiplier(&mut func, &find_word);
                     func.push(Str("(".to_string()))
                 }
-                ')' if i != 0 && chars[i - 1] != '(' =>
-                {
-                    if sum == count
-                    {
+                ')' if i != 0 && chars[i - 1] != '(' => {
+                    if sum == count {
                         sum = 0;
                     }
                     count -= 1;
                     func.push(Str(")".to_string()))
                 }
-                '|' =>
-                {
-                    if i + 1 != chars.len() && chars[i + 1] == '|' && abs
-                    {
+                '|' => {
+                    if i + 1 != chars.len() && chars[i + 1] == '|' && abs {
                         func.push(Str("||".to_string()));
                         i += 2;
                         continue;
-                    }
-                    else if abs
-                    {
+                    } else if abs {
                         place_multiplier(&mut func, &find_word);
                         func.push(Str("norm".to_string()));
                         func.push(Str("(".to_string()));
                         abs = false;
-                    }
-                    else
-                    {
+                    } else {
                         func.push(Str(")".to_string()));
                         abs = true;
                     }
                 }
-                '!' =>
-                {
-                    if i + 1 < chars.len() && chars[i + 1] == '='
-                    {
+                '!' => {
+                    if i + 1 < chars.len() && chars[i + 1] == '=' {
                         func.push(Str("!=".to_string()));
-                    }
-                    else if i != 0
+                    } else if i != 0
                         && (chars[i - 1].is_alphanumeric()
                             || (!func.is_empty() && func.last().unwrap().str_is(")")
                                 || func.last().unwrap().str_is("}")))
                     {
-                        if let Num(a) = func.clone().last().unwrap()
-                        {
-                            if a.real() < &0.0
-                            {
+                        if let Num(a) = func.clone().last().unwrap() {
+                            if a.real() < &0.0 {
                                 func.pop();
                                 func.push(Num(Complex::with_val(
                                     options.prec,
@@ -526,27 +433,18 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
                             || func.last().unwrap().str_is("}")
                         {
                             let mut count = 0;
-                            for (j, c) in func.iter().enumerate().rev()
-                            {
-                                if let Str(s) = c
-                                {
-                                    if s == "(" || s == "{"
-                                    {
+                            for (j, c) in func.iter().enumerate().rev() {
+                                if let Str(s) = c {
+                                    if s == "(" || s == "{" {
                                         count -= 1;
-                                    }
-                                    else if s == ")" || s == "}"
-                                    {
+                                    } else if s == ")" || s == "}" {
                                         count += 1;
                                     }
                                 }
-                                if count == 0
-                                {
-                                    if j != 0
-                                    {
-                                        if let Str(s) = &func[j - 1]
-                                        {
-                                            if s != "subfact" && s != "("
-                                            {
+                                if count == 0 {
+                                    if j != 0 {
+                                        if let Str(s) = &func[j - 1] {
+                                            if s != "subfact" && s != "(" {
                                                 func.insert(j - 1, Str("(".to_string()));
                                                 func.insert(j - 1, Str("fact".to_string()));
                                                 func.push(Str(")".to_string()));
@@ -566,8 +464,7 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
                         func.insert(func.len() - 1, Str("fact".to_string()));
                         func.insert(func.len() - 1, Str("(".to_string()));
                         func.push(Str(")".to_string()));
-                    }
-                    else if i != chars.len() - 1
+                    } else if i != chars.len() - 1
                         && (chars[i + 1].is_alphanumeric()
                             || chars[i + 1] == '('
                             || chars[i + 1] == '{'
@@ -575,8 +472,7 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
                             || chars[i + 1] == '-'
                             || chars[i + 1] == '!')
                     {
-                        if neg
-                        {
+                        if neg {
                             func.push(Num(n1.clone()));
                             func.push(Str("*".to_string()));
                             neg = false;
@@ -594,12 +490,10 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
         i += 1;
     }
     func.extend(vec![Str(")".to_string()); count as usize]);
-    if !pow.is_empty()
-    {
+    if !pow.is_empty() {
         let i = pow.matches('i').count() % 4;
         pow = pow.replace('i', "");
-        if pow.is_empty()
-        {
+        if pow.is_empty() {
             pow = "1".to_string();
         }
         if !func.is_empty()
@@ -609,36 +503,30 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
         }
         func.push(Num(Complex::with_val(
             options.prec,
-            match Complex::parse(pow.as_bytes())
-            {
+            match Complex::parse(pow.as_bytes()) {
                 Ok(n) => n,
                 Err(_) => return Err("exponent error"),
             },
         ) * Complex::with_val(options.prec, (0, 1))
             .pow(Complex::with_val(options.prec, i))));
     }
-    if !exp.is_empty()
-    {
+    if !exp.is_empty() {
         func.push(Str("^".to_string()));
         func.push(Num(Complex::with_val(
             options.prec,
-            match Complex::parse(exp.as_bytes())
-            {
+            match Complex::parse(exp.as_bytes()) {
                 Ok(n) => n,
                 Err(_) => return Err("exponent error"),
             },
         )));
     }
-    if !abs
-    {
+    if !abs {
         func.push(Str(")".to_string()));
     }
-    if neg
-    {
+    if neg {
         func.push(Num(n1));
     }
-    if func.is_empty()
-    {
+    if func.is_empty() {
         return Err("no function");
     }
     // for i in &func
@@ -653,26 +541,18 @@ pub fn get_func(input: &str, options: Options) -> Result<Vec<NumStr>, &'static s
     // }
     Ok(func)
 }
-fn place_multiplier(func: &mut Vec<NumStr>, find_word: &bool)
-{
-    if let Some(Str(s)) = func.last()
-    {
-        if !find_word && (s == ")" || s == "x" || s == "y" || s == "]" || s == "}")
-        {
+fn place_multiplier(func: &mut Vec<NumStr>, find_word: &bool) {
+    if let Some(Str(s)) = func.last() {
+        if !find_word && (s == ")" || s == "x" || s == "y" || s == "]" || s == "}") {
             func.push(Str('*'.to_string()))
         }
-    }
-    else if let Num(_) = func.last().unwrap_or(&Str("".to_string()))
-    {
+    } else if let Num(_) = func.last().unwrap_or(&Str("".to_string())) {
         func.push(Str('*'.to_string()))
-    }
-    else if let Vector(_) = func.last().unwrap_or(&Str("".to_string()))
-    {
+    } else if let Vector(_) = func.last().unwrap_or(&Str("".to_string())) {
         func.push(Str('*'.to_string()))
     }
 }
-pub fn is_func(word: &str) -> bool
-{
+pub fn is_func(word: &str) -> bool {
     let functions: HashSet<_> = [
         "sum",
         "product",

--- a/src/print.rs
+++ b/src/print.rs
@@ -15,19 +15,15 @@ use crate::{
 };
 use rug::{float::Constant::Pi, ops::CompleteRound, Complex, Float, Integer};
 use std::{cmp::Ordering, str::FromStr};
-pub fn print_answer(input: &str, func: Vec<NumStr>, options: Options)
-{
-    if can_graph(input)
-    {
+pub fn print_answer(input: &str, func: Vec<NumStr>, options: Options) {
+    if can_graph(input) {
         return;
     }
-    let num = match do_math(func, options.deg, options.prec)
-    {
+    let num = match do_math(func, options.deg, options.prec) {
         Ok(num) => num,
         Err(_) => return,
     };
-    if let Num(n) = num
-    {
+    if let Num(n) = num {
         let a = get_output(&options, &n);
         print!(
             "{}{}{}",
@@ -35,22 +31,16 @@ pub fn print_answer(input: &str, func: Vec<NumStr>, options: Options)
             a.1,
             if options.color { "\x1b[0m" } else { "" }
         );
-    }
-    else if let Vector(mut v) = num
-    {
-        if options.polar
-        {
+    } else if let Vector(mut v) = num {
+        if options.polar {
             v = to_polar(
                 v,
-                match options.deg
-                {
-                    Degrees =>
-                    {
+                match options.deg {
+                    Degrees => {
                         Complex::with_val(options.prec, 180) / Complex::with_val(options.prec, Pi)
                     }
                     Radians => Complex::with_val(options.prec, 1),
-                    Gradians =>
-                    {
+                    Gradians => {
                         Complex::with_val(options.prec, 200) / Complex::with_val(options.prec, Pi)
                     }
                 },
@@ -58,82 +48,57 @@ pub fn print_answer(input: &str, func: Vec<NumStr>, options: Options)
         }
         let mut output = if options.polar { "[" } else { "{" }.to_string();
         let mut out;
-        for (k, i) in v.iter().enumerate()
-        {
+        for (k, i) in v.iter().enumerate() {
             out = get_output(&options, i);
             output += out.0.as_str();
             output += out.1.as_str();
-            if options.color
-            {
+            if options.color {
                 output += "\x1b[0m";
             }
-            if k == v.len() - 1
-            {
+            if k == v.len() - 1 {
                 output += if options.polar { "]" } else { "}" };
-            }
-            else
-            {
+            } else {
                 output += ",";
             }
         }
         print!("{}{}", output, if options.color { "\x1b[0m" } else { "" });
-    }
-    else if let Matrix(v) = num
-    {
-        let mut output = if options.multi
-        {
+    } else if let Matrix(v) = num {
+        let mut output = if options.multi {
             String::new()
-        }
-        else
-        {
+        } else {
             "{".to_string()
         };
         let mut out;
-        for (l, j) in v.iter().enumerate()
-        {
-            if !options.multi
-            {
+        for (l, j) in v.iter().enumerate() {
+            if !options.multi {
                 output += "{";
             }
-            for (k, i) in j.iter().enumerate()
-            {
+            for (k, i) in j.iter().enumerate() {
                 out = get_output(&options, i);
                 output += out.0.as_str();
                 output += out.1.as_str();
-                if options.color
-                {
+                if options.color {
                     output += "\x1b[0m";
                 }
-                if k == j.len() - 1
-                {
-                    if !options.multi
-                    {
+                if k == j.len() - 1 {
+                    if !options.multi {
                         output += "}";
                     }
-                }
-                else if options.tabbed
-                {
+                } else if options.tabbed {
                     output += "\t";
-                }
-                else
-                {
+                } else {
                     output += ",";
                 }
             }
-            if l != v.len() - 1
-            {
-                if options.multi
-                {
+            if l != v.len() - 1 {
+                if options.multi {
                     output += "\n";
-                }
-                else
-                {
+                } else {
                     output += ",";
                 }
             }
         }
-        if !options.multi
-        {
+        if !options.multi {
             output += "}";
         }
         print!("{}{}", output, if options.color { "\x1b[0m" } else { "" });
@@ -146,8 +111,7 @@ pub fn print_concurrent(
     options: Options,
     start: usize,
     end: usize,
-) -> usize
-{
+) -> usize {
     let input = &input_var(
         &unmodified_input.iter().collect::<String>(),
         vars,
@@ -155,127 +119,89 @@ pub fn print_concurrent(
         options,
     )
     .replace('_', &format!("({})", last.iter().collect::<String>()));
-    if can_graph(input)
-    {
+    if can_graph(input) {
         clear(unmodified_input, start, end, options);
         return 0;
     }
     let num = match do_math(
-        match get_func(input, options)
-        {
+        match get_func(input, options) {
             Ok(f) => f,
-            Err(s) =>
-            {
+            Err(s) => {
                 handle_err(s, unmodified_input, options, start, end);
                 return 0;
             }
         },
         options.deg,
         options.prec,
-    )
-    {
+    ) {
         Ok(n) => n,
-        Err(s) =>
-        {
+        Err(s) => {
             handle_err(s, unmodified_input, options, start, end);
             return 0;
         }
     };
     let mut frac = 0;
-    if let Num(n) = num
-    {
-        let sign = if n.real() != &0.0 && n.imag().is_sign_positive()
-        {
+    if let Num(n) = num {
+        let sign = if n.real() != &0.0 && n.imag().is_sign_positive() {
             "+"
-        }
-        else
-        {
+        } else {
             ""
         }
         .to_owned();
-        let (frac_a, frac_b) = if options.frac || options.frac_iter == 0
-        {
+        let (frac_a, frac_b) = if options.frac || options.frac_iter == 0 {
             let fa = fraction(n.real().clone(), options);
             let fb = fraction(n.imag().clone(), options);
-            match (!fa.is_empty(), !fb.is_empty())
-            {
-                (true, true) =>
-                {
+            match (!fa.is_empty(), !fb.is_empty()) {
+                (true, true) => {
                     frac = 1;
                     (
-                        if n.real() == &0.0 && n.imag() != &0.0
-                        {
+                        if n.real() == &0.0 && n.imag() != &0.0 {
                             "".to_string()
-                        }
-                        else
-                        {
+                        } else {
                             fa
                         },
-                        if n.imag() == &0.0
-                        {
+                        if n.imag() == &0.0 {
                             "".to_string()
-                        }
-                        else
-                        {
+                        } else {
                             sign + fb.as_str()
-                                + if options.color
-                                {
+                                + if options.color {
                                     "\x1b[93mi\x1b[0m"
-                                }
-                                else
-                                {
+                                } else {
                                     "i"
                                 }
                         },
                     )
                 }
-                (true, _) =>
-                {
+                (true, _) => {
                     frac = 1;
                     (
-                        if n.real() == &0.0 && n.imag() != &0.0
-                        {
+                        if n.real() == &0.0 && n.imag() != &0.0 {
                             "".to_string()
-                        }
-                        else
-                        {
+                        } else {
                             fa
                         },
-                        if n.imag() == &0.0
-                        {
+                        if n.imag() == &0.0 {
                             "".to_string()
-                        }
-                        else
-                        {
+                        } else {
                             get_output(&options, &n).1 + if options.color { "\x1b[0m" } else { "" }
                         },
                     )
                 }
-                (_, true) =>
-                {
+                (_, true) => {
                     frac = 1;
                     (
-                        if n.real() == &0.0 && n.imag() != &0.0
-                        {
+                        if n.real() == &0.0 && n.imag() != &0.0 {
                             "".to_string()
-                        }
-                        else
-                        {
+                        } else {
                             get_output(&options, &n).0
                         },
-                        if n.imag() == &0.0
-                        {
+                        if n.imag() == &0.0 {
                             "".to_string()
-                        }
-                        else
-                        {
+                        } else {
                             sign + fb.as_str()
-                                + if options.color
-                                {
+                                + if options.color {
                                     "\x1b[93mi\x1b[0m"
-                                }
-                                else
-                                {
+                                } else {
                                     "i"
                                 }
                         },
@@ -283,9 +209,7 @@ pub fn print_concurrent(
                 }
                 _ => ("".to_string(), "".to_string()),
             }
-        }
-        else
-        {
+        } else {
             ("".to_string(), "".to_string())
         };
         let output = get_output(&options, &n);
@@ -304,122 +228,85 @@ pub fn print_concurrent(
             .len();
         if (frac == 1 && !options.frac)
             || (frac_a.len() + frac_b.len()
-                - if options.color && !frac_b.is_empty()
-                {
+                - if options.color && !frac_b.is_empty() {
                     5
-                }
-                else
-                {
+                } else {
                     0
                 })
                 > terlen
         {
             frac = 0;
         }
-        if len1 + len2 > terlen
-        {
+        if len1 + len2 > terlen {
             let num = (len1 as f64 / terlen as f64).ceil() as usize
-                + if len2 != 0
-                {
+                + if len2 != 0 {
                     ((len2 - 1) as f64 / terlen as f64).ceil() as usize - 1
-                }
-                else
-                {
+                } else {
                     0
                 }
                 - 1;
             print!(
                 "\x1B[0J{}\n\x1B[2K\x1B[1G{}{}{}{}\x1b[A\x1b[A\x1B[2K\x1B[1G{}{}{}",
-                if frac == 1
-                {
+                if frac == 1 {
                     format!("\n\x1B[2K\x1B[1G{}{}", frac_a, frac_b)
-                }
-                else
-                {
+                } else {
                     "".to_string()
                 },
                 output.0,
                 if len1 != 0 && len2 != 0 { "\n" } else { "" },
                 &output.1.replace('+', ""),
                 "\x1b[A".repeat(num + frac - if len1 == 0 || len2 == 0 { 1 } else { 0 }),
-                if options.prompt
-                {
-                    if options.color
-                    {
+                if options.prompt {
+                    if options.color {
                         "\x1b[94m> \x1b[96m"
-                    }
-                    else
-                    {
+                    } else {
                         "> "
                     }
-                }
-                else if options.color
-                {
+                } else if options.color {
                     "\x1b[96m"
-                }
-                else
-                {
+                } else {
                     ""
                 },
                 &unmodified_input[start..end].iter().collect::<String>(),
                 if options.color { "\x1b[0m" } else { "" },
             );
             frac += num + if len1 != 0 && len2 != 0 { 1 } else { 0 };
-        }
-        else
-        {
+        } else {
             print!(
                 "\x1B[0J{}\n\x1B[2K\x1B[1G{}{}\x1b[A{}\x1B[2K\x1B[1G{}{}{}",
-                if frac == 1
-                {
+                if frac == 1 {
                     format!("\n\x1B[2K\x1B[1G{}{}", frac_a, frac_b)
-                }
-                else
-                {
+                } else {
                     "".to_string()
                 },
                 output.0,
                 output.1,
                 if frac == 1 { "\x1b[A" } else { "" },
-                if options.prompt
-                {
-                    if options.color
-                    {
+                if options.prompt {
+                    if options.color {
                         "\x1b[94m> \x1b[96m"
-                    }
-                    else
-                    {
+                    } else {
                         "> "
                     }
-                }
-                else if options.color
-                {
+                } else if options.color {
                     "\x1b[96m"
-                }
-                else
-                {
+                } else {
                     ""
                 },
                 &unmodified_input[start..end].iter().collect::<String>(),
                 if options.color { "\x1b[0m" } else { "" }
             );
         }
-    }
-    else if let Vector(mut v) = num
-    {
-        if options.polar
-        {
+    } else if let Vector(mut v) = num {
+        if options.polar {
             v = to_polar(
                 v,
-                match options.deg
-                {
-                    Degrees =>
-                    {
+                match options.deg {
+                    Degrees => {
                         Complex::with_val(options.prec, 180) / Complex::with_val(options.prec, Pi)
                     }
                     Radians => Complex::with_val(options.prec, 1),
-                    Gradians =>
-                    {
+                    Gradians => {
                         Complex::with_val(options.prec, 200) / Complex::with_val(options.prec, Pi)
                     }
                 },
@@ -429,70 +316,49 @@ pub fn print_concurrent(
         let mut frac_out = if options.polar { "[" } else { "{" }.to_string();
         let mut out;
         let mut frac_temp;
-        for (k, i) in v.iter().enumerate()
-        {
+        for (k, i) in v.iter().enumerate() {
             out = get_output(&options, i);
-            if options.frac || options.frac_iter == 0
-            {
+            if options.frac || options.frac_iter == 0 {
                 frac_temp = fraction(i.real().clone(), options);
-                frac_out += if !frac_temp.is_empty()
-                {
+                frac_out += if !frac_temp.is_empty() {
                     &frac_temp
-                }
-                else
-                {
+                } else {
                     &out.0
                 };
                 frac_temp = fraction(i.imag().clone(), options);
-                frac_out += &if !frac_temp.is_empty()
-                {
+                frac_out += &if !frac_temp.is_empty() {
                     format!(
                         "{}{}{}",
-                        (if i.real() != &0.0 && i.imag().is_sign_positive() && i.imag() != &0.0
-                        {
+                        (if i.real() != &0.0 && i.imag().is_sign_positive() && i.imag() != &0.0 {
                             "+"
-                        }
-                        else
-                        {
+                        } else {
                             ""
                         }),
                         frac_temp,
-                        (if i.imag() != &0.0
-                        {
-                            if options.color
-                            {
+                        (if i.imag() != &0.0 {
+                            if options.color {
                                 "\x1b[93mi\x1b[0m"
-                            }
-                            else
-                            {
+                            } else {
                                 "i"
                             }
-                        }
-                        else
-                        {
+                        } else {
                             ""
                         })
                     )
-                }
-                else
-                {
+                } else {
                     out.clone().1
                 };
             }
             output += &out.0;
             output += &out.1;
-            if options.color
-            {
+            if options.color {
                 output += "\x1b[0m";
                 frac_out += "\x1b[0m";
             }
-            if k == v.len() - 1
-            {
+            if k == v.len() - 1 {
                 output += if options.polar { "]" } else { "}" };
                 frac_out += if options.polar { "]" } else { "}" };
-            }
-            else
-            {
+            } else {
                 output += ",";
                 frac_out += ",";
             }
@@ -504,8 +370,7 @@ pub fn print_concurrent(
             .replace("\x1b[92m", "")
             .len()
             - 1;
-        if frac_out != output
-        {
+        if frac_out != output {
             frac = 1;
         }
         if (frac == 1 && !options.frac)
@@ -522,148 +387,105 @@ pub fn print_concurrent(
         let num = (len as f64 / terlen as f64).floor() as usize;
         print!(
             "\x1B[0J{}\n\x1B[2K\x1B[1G{}{}\x1b[A{}\x1B[2K\x1B[1G{}{}{}",
-            if frac == 1
-            {
+            if frac == 1 {
                 format!("\n\x1B[2K\x1B[1G{}", frac_out)
-            }
-            else
-            {
+            } else {
                 "".to_string()
             },
             output,
             "\x1b[A".repeat(num),
             if frac == 1 { "\x1b[A" } else { "" },
-            if options.prompt
-            {
-                if options.color
-                {
+            if options.prompt {
+                if options.color {
                     "\x1b[94m> \x1b[96m"
-                }
-                else
-                {
+                } else {
                     "> "
                 }
-            }
-            else if options.color
-            {
+            } else if options.color {
                 "\x1b[96m"
-            }
-            else
-            {
+            } else {
                 ""
             },
             &unmodified_input[start..end].iter().collect::<String>(),
             if options.color { "\x1b[0m" } else { "" }
         );
         frac += num;
-    }
-    else if let Matrix(v) = num
-    {
+    } else if let Matrix(v) = num {
         let mut output = if !options.multi { "{" } else { "" }.to_string();
         let mut frac_out = if !options.multi { "{" } else { "" }.to_string();
         let mut out;
         let mut frac_temp;
         let mut num = 0;
-        for (l, j) in v.iter().enumerate()
-        {
-            if !options.multi
-            {
+        for (l, j) in v.iter().enumerate() {
+            if !options.multi {
                 output += "{";
                 frac_out += "{";
             }
-            for (k, i) in j.iter().enumerate()
-            {
+            for (k, i) in j.iter().enumerate() {
                 out = get_output(&options, i);
-                if options.frac || options.frac_iter == 0
-                {
+                if options.frac || options.frac_iter == 0 {
                     frac_temp = fraction(i.real().clone(), options);
-                    frac_out += if !frac_temp.is_empty()
-                    {
+                    frac_out += if !frac_temp.is_empty() {
                         &frac_temp
-                    }
-                    else
-                    {
+                    } else {
                         &out.0
                     };
                     frac_temp = fraction(i.imag().clone(), options);
-                    frac_out += &if !frac_temp.is_empty()
-                    {
+                    frac_out += &if !frac_temp.is_empty() {
                         format!(
                             "{}{}{}",
                             (if i.real() != &0.0 && i.imag().is_sign_positive() && i.imag() != &0.0
                             {
                                 "+"
-                            }
-                            else
-                            {
+                            } else {
                                 ""
                             }),
                             frac_temp,
-                            (if i.imag() != &0.0
-                            {
-                                if options.color
-                                {
+                            (if i.imag() != &0.0 {
+                                if options.color {
                                     "\x1b[93mi\x1b[0m"
-                                }
-                                else
-                                {
+                                } else {
                                     "i"
                                 }
-                            }
-                            else
-                            {
+                            } else {
                                 ""
                             })
                         )
-                    }
-                    else
-                    {
+                    } else {
                         out.clone().1
                     };
                 }
                 output += &out.0;
                 output += &out.1;
-                if options.color
-                {
+                if options.color {
                     output += "\x1b[0m";
                     frac_out += "\x1b[0m";
                 }
-                if k == j.len() - 1
-                {
-                    if !options.multi
-                    {
+                if k == j.len() - 1 {
+                    if !options.multi {
                         output += "}";
                         frac_out += "}";
                     }
-                }
-                else if options.tabbed
-                {
+                } else if options.tabbed {
                     output += "\t";
                     frac_out += "\t";
-                }
-                else
-                {
+                } else {
                     output += ",";
                     frac_out += ",";
                 }
             }
-            if l != v.len() - 1
-            {
-                if options.multi
-                {
+            if l != v.len() - 1 {
+                if options.multi {
                     num += 1;
                     output += "\n";
                     frac_out += "\n";
-                }
-                else
-                {
+                } else {
                     output += ",";
                     frac_out += ",";
                 }
             }
         }
-        if !options.multi
-        {
+        if !options.multi {
             output += "}";
             frac_out += "}";
         }
@@ -674,8 +496,7 @@ pub fn print_concurrent(
             .replace("\x1b[92m", "")
             .len()
             - 1;
-        if frac_out != output
-        {
+        if frac_out != output {
             frac = 1;
         }
         if (frac == 1 && !options.frac)
@@ -689,12 +510,9 @@ pub fn print_concurrent(
         {
             frac = 0;
         }
-        if !options.multi
-        {
+        if !options.multi {
             num += (len as f64 / terlen as f64).floor() as usize;
-        }
-        else
-        {
+        } else {
             let mut len = 0;
             for i in output
                 .replace("\x1b[0m", "")
@@ -703,12 +521,9 @@ pub fn print_concurrent(
                 .chars()
             {
                 len += 1;
-                if i == '\n'
-                {
+                if i == '\n' {
                     len = 0
-                }
-                else if len > terlen
-                {
+                } else if len > terlen {
                     len = 0;
                     num += 1;
                 }
@@ -718,113 +533,75 @@ pub fn print_concurrent(
         }
         print!(
             "\x1B[0J{}\n\x1B[2K\x1B[1G{}{}\x1b[A{}\x1B[2K\x1B[1G{}{}{}",
-            if frac == 1
-            {
+            if frac == 1 {
                 format!("\n\x1B[2K\x1B[1G{}", frac_out)
-            }
-            else
-            {
+            } else {
                 "".to_string()
             },
             output,
             "\x1b[A".repeat(num),
             if frac == 1 { "\x1b[A" } else { "" },
-            if options.prompt
-            {
-                if options.color
-                {
+            if options.prompt {
+                if options.color {
                     "\x1b[94m> \x1b[96m"
-                }
-                else
-                {
+                } else {
                     "> "
                 }
-            }
-            else if options.color
-            {
+            } else if options.color {
                 "\x1b[96m"
-            }
-            else
-            {
+            } else {
                 ""
             },
             &unmodified_input[start..end].iter().collect::<String>(),
             if options.color { "\x1b[0m" } else { "" }
         );
         frac += num;
-    }
-    else
-    {
+    } else {
         handle_err("str err", unmodified_input, options, start, end);
     }
     frac
 }
-pub fn get_output(options: &Options, num: &Complex) -> (String, String)
-{
-    let sign = if num.real() != &0.0 && num.imag().is_sign_positive()
-    {
+pub fn get_output(options: &Options, num: &Complex) -> (String, String) {
+    let sign = if num.real() != &0.0 && num.imag().is_sign_positive() {
         "+"
-    }
-    else
-    {
+    } else {
         ""
     }
     .to_owned();
     let mut n;
-    let dec = if options.decimal_places == 0
-    {
+    let dec = if options.decimal_places == 0 {
         1
-    }
-    else
-    {
+    } else {
         options.decimal_places
     };
-    if options.base != 10
-    {
+    if options.base != 10 {
         (
-            if num.real() != &0.0
-            {
+            if num.real() != &0.0 {
                 n = num.real().to_string_radix(options.base as i32, None);
-                if n.contains('e')
-                {
+                if n.contains('e') {
                     n
-                }
-                else
-                {
+                } else {
                     n.trim_end_matches('0').trim_end_matches('.').to_owned()
                 }
-            }
-            else if num.imag() == &0.0
-            {
+            } else if num.imag() == &0.0 {
                 "0".to_owned()
-            }
-            else
-            {
+            } else {
                 "".to_owned()
             },
-            if num.imag() != &0.0
-            {
+            if num.imag() != &0.0 {
                 n = num.imag().to_string_radix(options.base as i32, None);
-                sign + &if n.contains('e')
-                {
+                sign + &if n.contains('e') {
                     n
-                }
-                else
-                {
+                } else {
                     n.trim_end_matches('0').trim_end_matches('.').to_owned()
                 } + if options.color { "\x1b[93mi" } else { "i" }
-            }
-            else
-            {
+            } else {
                 "".to_string()
             },
         )
-    }
-    else if options.sci
-    {
+    } else if options.sci {
         (
-            if num.real() != &0.0
-            {
+            if num.real() != &0.0 {
                 add_commas(
                     &remove_trailing_zeros(&format!("{:e}", num.real()), dec, num.real().prec()),
                     options.comma,
@@ -832,49 +609,33 @@ pub fn get_output(options: &Options, num: &Complex) -> (String, String)
                 .replace("e0", "")
                 .replace(
                     'e',
-                    if options.small_e
-                    {
-                        if options.color
-                        {
+                    if options.small_e {
+                        if options.color {
                             "\x1b[92me"
-                        }
-                        else
-                        {
+                        } else {
                             "e"
                         }
-                    }
-                    else if options.color
-                    {
+                    } else if options.color {
                         "\x1b[92mE"
-                    }
-                    else
-                    {
+                    } else {
                         "E"
                     },
                 ) + if options.color { "\x1b[0m" } else { "" }
-            }
-            else if num.imag() == &0.0
-            {
+            } else if num.imag() == &0.0 {
                 "0".to_owned()
-            }
-            else
-            {
+            } else {
                 "".to_owned()
             },
-            if num.imag() != &0.0
-            {
+            if num.imag() != &0.0 {
                 add_commas(
                     &(sign.as_str().to_owned()
                         + &remove_trailing_zeros(
                             &format!(
                                 "{:e}{}",
                                 num.imag(),
-                                if options.color
-                                {
+                                if options.color {
                                     "\x1b[93mi\x1b[0m"
-                                }
-                                else
-                                {
+                                } else {
                                     "i"
                                 }
                             ),
@@ -886,35 +647,23 @@ pub fn get_output(options: &Options, num: &Complex) -> (String, String)
                 .replace("e0", "")
                 .replace(
                     'e',
-                    if options.small_e
-                    {
-                        if options.color
-                        {
+                    if options.small_e {
+                        if options.color {
                             "\x1b[92me"
-                        }
-                        else
-                        {
+                        } else {
                             "e"
                         }
-                    }
-                    else if options.color
-                    {
+                    } else if options.color {
                         "\x1b[92mE"
-                    }
-                    else
-                    {
+                    } else {
                         "E"
                     },
                 ) + if options.color { "\x1b[0m" } else { "" }
-            }
-            else
-            {
+            } else {
                 "".to_owned()
             },
         )
-    }
-    else
-    {
+    } else {
         n = add_commas(
             &to_string(num.real(), options.decimal_places, false),
             options.comma,
@@ -925,114 +674,83 @@ pub fn get_output(options: &Options, num: &Complex) -> (String, String)
             options.comma,
         );
         (
-            if n == "0" && im != "0"
-            {
+            if n == "0" && im != "0" {
                 "".to_string()
-            }
-            else
-            {
+            } else {
                 n
             },
-            if im == "0"
-            {
+            if im == "0" {
                 "".to_string()
-            }
-            else
-            {
+            } else {
                 sign + &im + if options.color { "\x1b[93mi" } else { "i" }
             },
         )
     }
 }
-fn to_string(num: &Float, decimals: usize, imag: bool) -> String
-{
+fn to_string(num: &Float, decimals: usize, imag: bool) -> String {
     let (neg, mut str, exp) = num.to_sign_string_exp(10, None);
     let mut neg = if neg { "-" } else { "" };
-    if exp.is_none()
-    {
-        return if str == "0"
-        {
+    if exp.is_none() {
+        return if str == "0" {
             "0".to_string()
-        }
-        else
-        {
+        } else {
             format!("{}{}", neg, str)
         };
     }
     let exp = exp.unwrap();
-    let decimals = if decimals == usize::MAX - 1 && (get_terminal_width() as i32) > (2i32 + exp)
-    {
+    let decimals = if decimals == usize::MAX - 1 && (get_terminal_width() as i32) > (2i32 + exp) {
         (get_terminal_width() as i32
-            - match exp.cmp(&0)
-            {
+            - match exp.cmp(&0) {
                 Ordering::Equal => 2i32,
                 Ordering::Less => 3i32,
                 Ordering::Greater => 1i32 + exp,
             }
             - if imag { 1 } else { 0 }
             - if !neg.is_empty() { 1 } else { 0 }) as usize
-    }
-    else
-    {
+    } else {
         decimals
     };
-    if str.len() as i32 == exp
-    {
-        return if str == "0"
-        {
+    if str.len() as i32 == exp {
+        return if str == "0" {
             "0".to_string()
-        }
-        else
-        {
+        } else {
             format!("{}{}", neg, str)
         };
     }
-    if exp > str.len() as i32
-    {
+    if exp > str.len() as i32 {
         str.push_str(&"0".repeat(exp as usize - str.len()));
     }
     let mut zeros = String::new();
-    if exp < 0
-    {
+    if exp < 0 {
         zeros = "0".repeat(-exp as usize);
         str.insert_str(0, &zeros);
         str.insert(1, '.');
-    }
-    else
-    {
+    } else {
         str.insert(exp as usize, '.');
     }
     let mut split = str.split('.');
     let mut l = split.next().unwrap().to_string();
     let mut r = split.next().unwrap().to_string();
-    if r.is_empty()
-    {
-        return if str == "0"
-        {
+    if r.is_empty() {
+        return if str == "0" {
             "0".to_string()
-        }
-        else
-        {
+        } else {
             format!("{}{}", neg, l)
         };
     }
-    if r.len() > decimals
-    {
+    if r.len() > decimals {
         r.insert(decimals, '.');
     }
     let mut d = Float::with_val(num.prec(), Float::parse(&r).unwrap())
         .to_integer()
         .unwrap();
-    if exp > 0
-    {
+    if exp > 0 {
         zeros = "0".repeat(r.to_string().len() - r.to_string().trim_start_matches('0').len());
-        if d.to_string() == 10.0f64.powi(decimals as i32 - 1).to_string()
-        {
+        if d.to_string() == 10.0f64.powi(decimals as i32 - 1).to_string() {
             zeros.pop();
         }
     }
-    if zeros.is_empty() && d.to_string().trim_end_matches('0') == "1" && r.starts_with('9')
-    {
+    if zeros.is_empty() && d.to_string().trim_end_matches('0') == "1" && r.starts_with('9') {
         let t: Float = Float::with_val(
             num.prec(),
             Float::parse(if l.is_empty() { "0" } else { &l }).unwrap(),
@@ -1040,27 +758,20 @@ fn to_string(num: &Float, decimals: usize, imag: bool) -> String
         l = t.to_integer().unwrap().to_string();
         d = Integer::new();
     }
-    if d.to_string() == "0" && (l.is_empty() || l == "0")
-    {
+    if d.to_string() == "0" && (l.is_empty() || l == "0") {
         neg = ""
     }
-    if decimals == 0
-    {
-        if zeros.is_empty() && d.to_string().chars().next().unwrap().to_digit(10).unwrap() == 1
-        {
+    if decimals == 0 {
+        if zeros.is_empty() && d.to_string().chars().next().unwrap().to_digit(10).unwrap() == 1 {
             format!(
                 "{}{}",
                 neg,
                 Integer::from_str(&l).unwrap_or(Integer::new()) + 1
             )
-        }
-        else
-        {
+        } else {
             format!("{}{}", neg, if l.is_empty() { "0" } else { &l })
         }
-    }
-    else
-    {
+    } else {
         format!(
             "{}{}.{}{}",
             neg,
@@ -1073,43 +784,34 @@ fn to_string(num: &Float, decimals: usize, imag: bool) -> String
         .to_string()
     }
 }
-fn add_commas(input: &str, commas: bool) -> String
-{
-    if !commas
-    {
+fn add_commas(input: &str, commas: bool) -> String {
+    if !commas {
         return input.to_owned();
     }
     let mut split = input.split('.');
     let mut result = String::new();
     let mut count = 0;
     let mut exp = false;
-    for c in split.next().unwrap().chars().rev()
-    {
-        if c == 'e'
-        {
+    for c in split.next().unwrap().chars().rev() {
+        if c == 'e' {
             exp = true;
         }
-        if count == 3 && !exp
-        {
+        if count == 3 && !exp {
             result.push(',');
             count = 0;
         }
         result.push(c);
         count += 1;
     }
-    if split.clone().count() == 1
-    {
+    if split.clone().count() == 1 {
         let mut result = result.chars().rev().collect::<String>();
         result.push('.');
         count = 0;
-        for c in split.next().unwrap().chars()
-        {
-            if c == 'e'
-            {
+        for c in split.next().unwrap().chars() {
+            if c == 'e' {
                 exp = true;
             }
-            if count == 3 && !exp
-            {
+            if count == 3 && !exp {
                 result.push(',');
                 count = 0;
             }
@@ -1120,58 +822,41 @@ fn add_commas(input: &str, commas: bool) -> String
     }
     result.chars().rev().collect::<String>()
 }
-fn remove_trailing_zeros(input: &str, dec: usize, prec: u32) -> String
-{
-    let pos = match input.find('e')
-    {
+fn remove_trailing_zeros(input: &str, dec: usize, prec: u32) -> String {
+    let pos = match input.find('e') {
         Some(n) => n,
-        None =>
-        {
+        None => {
             return input
                 .trim_end_matches('0')
                 .trim_end_matches('.')
                 .to_string()
         }
     };
-    let dec = if dec == usize::MAX - 1
-    {
+    let dec = if dec == usize::MAX - 1 {
         get_terminal_width()
-            - (if &input[pos..] == "e0"
-            {
+            - (if &input[pos..] == "e0" {
                 1
-            }
-            else if &input[pos..] == "e0\x1b[93mi"
-            {
+            } else if &input[pos..] == "e0\x1b[93mi" {
                 2
-            }
-            else
-            {
+            } else {
                 (input.len() - (pos - 1)) - if input.ends_with("\x1b[93mi") { 5 } else { 0 }
             })
             - if input.starts_with('-') { 1 } else { 0 }
-    }
-    else
-    {
+    } else {
         dec
     };
-    if dec > pos
-    {
+    if dec > pos {
         input[..pos]
             .trim_end_matches('0')
             .trim_end_matches('.')
             .to_string()
             + &input[pos..]
-    }
-    else
-    {
+    } else {
         let mut sign = String::new();
-        let mut num = if input.starts_with('-')
-        {
+        let mut num = if input.starts_with('-') {
             sign = "-".to_string();
             input[1..pos].to_string()
-        }
-        else
-        {
+        } else {
             input[0..pos].to_string()
         };
         num.remove(1);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,8 +8,7 @@ use crate::{
 };
 use rug::{float::Constant::Pi, Complex};
 #[test]
-fn test_math()
-{
+fn test_math() {
     let input = input_var(
         "pi+tau*e/2i^(sqrt(2))/3*3-log(2-2i,-3+i)+sqrt(2)^(sqrt(2))",
         &get_vars(512),

--- a/src/vars.rs
+++ b/src/vars.rs
@@ -5,8 +5,7 @@ pub fn input_var(
     vars: &[[String; 2]],
     dont_do: Option<&str>,
     options: Options,
-) -> String
-{
+) -> String {
     let chars = input
         .replace('[', "(car{")
         .replace(']', "})")
@@ -29,25 +28,17 @@ pub fn input_var(
     let mut commas: Vec<usize>;
     let mut stack_end = Vec::new();
     let mut stack_start = Vec::new();
-    for c in &chars
-    {
-        match c
-        {
+    for c in &chars {
+        match c {
             '(' => stack_end.push(')'),
             '{' => stack_end.push('}'),
-            ')' | '}' =>
-            {
-                if let Some(top) = stack_end.last()
-                {
-                    if top == c
-                    {
+            ')' | '}' => {
+                if let Some(top) = stack_end.last() {
+                    if top == c {
                         stack_end.pop();
                     }
-                }
-                else
-                {
-                    match c
-                    {
+                } else {
+                    match c {
                         ')' => stack_start.push('('),
                         '}' => stack_start.push('{'),
                         _ => (),
@@ -58,35 +49,29 @@ pub fn input_var(
         }
     }
     let mut input = String::new();
-    while let Some(top) = stack_start.pop()
-    {
+    while let Some(top) = stack_start.pop() {
         input.push(top);
     }
-    for i in &chars
-    {
+    for i in &chars {
         input.push(*i)
     }
-    while let Some(top) = stack_end.pop()
-    {
+    while let Some(top) = stack_end.pop() {
         input.push(top);
     }
     let chars = input.chars().collect::<Vec<char>>();
     let mut count;
     let mut vl;
     let mut push = true;
-    while i < chars.len()
-    {
+    while i < chars.len() {
         c = chars[i];
         not_pushed = true;
-        if !c.is_alphabetic()
-        {
+        if !c.is_alphabetic() {
             output.push(c);
             push = true;
             i += 1;
             continue;
         }
-        for var in vars
-        {
+        for var in vars {
             vl = var[0].chars().collect::<Vec<char>>().len();
             if var[0] != "e"
                 || (!options.small_e
@@ -108,32 +93,23 @@ pub fn input_var(
                 {
                     o = i;
                     count = 0;
-                    for (f, c) in chars[i..].iter().enumerate()
-                    {
-                        if *c == '('
-                        {
+                    for (f, c) in chars[i..].iter().enumerate() {
+                        if *c == '(' {
                             count += 1;
-                        }
-                        else if *c == ')'
-                        {
+                        } else if *c == ')' {
                             count -= 1;
-                            if count == 0
-                            {
+                            if count == 0 {
                                 i += f;
                                 break;
                             }
                         }
                     }
-                    if i == j
-                    {
+                    if i == j {
                         i = input.len() - 1
                     }
-                    if chars[j..i + 1].iter().collect::<String>() == var[0]
-                    {
-                        if let Some(n) = dont_do
-                        {
-                            if n == var[0]
-                            {
+                    if chars[j..i + 1].iter().collect::<String>() == var[0] {
+                        if let Some(n) = dont_do {
+                            if n == var[0] {
                                 return String::new();
                             }
                         }
@@ -141,75 +117,55 @@ pub fn input_var(
                         output.push('(');
                         output.push_str(&input_var(&var[1], vars, Some(&var[0]), options));
                         output.push(')');
-                    }
-                    else if push
-                    {
+                    } else if push {
                         k = 0;
-                        for (f, c) in chars[j + 2..].iter().enumerate()
-                        {
-                            if *c == ')'
-                            {
+                        for (f, c) in chars[j + 2..].iter().enumerate() {
+                            if *c == ')' {
                                 k = f + j + 3;
                                 break;
-                            }
-                            else if f + j + 3 == chars.len()
-                            {
+                            } else if f + j + 3 == chars.len() {
                                 k = f + j + 4;
                                 break;
                             }
                         }
-                        if k == 0
-                        {
+                        if k == 0 {
                             continue;
                         }
                         v = var[0].chars().collect::<Vec<char>>();
-                        if let Some(n) = dont_do
-                        {
-                            if n == var[0]
-                            {
+                        if let Some(n) = dont_do {
+                            if n == var[0] {
                                 return String::new();
                             }
                         }
-                        if input.contains(',') && var[0].contains(',') && chars.len() > 4
-                        {
+                        if input.contains(',') && var[0].contains(',') && chars.len() > 4 {
                             not_pushed = false;
                             output.push('(');
                             temp = &chars
                                 [j + var[0].chars().position(|c| c == '(').unwrap() + 1..i + 1];
-                            if temp.ends_with(&[')'])
-                            {
+                            if temp.ends_with(&[')']) {
                                 temp = &temp[..temp.len() - 1];
                             }
                             commas = Vec::new();
                             count = 0;
-                            for (f, c) in temp.iter().enumerate()
-                            {
-                                if c == &'(' || c == &'{' || c == &'['
-                                {
+                            for (f, c) in temp.iter().enumerate() {
+                                if c == &'(' || c == &'{' || c == &'[' {
                                     count += 1;
-                                }
-                                else if c == &')' || c == &'}' || c == &']'
-                                {
+                                } else if c == &')' || c == &'}' || c == &']' {
                                     count -= 1;
-                                }
-                                else if c == &',' && count == 0
-                                {
+                                } else if c == &',' && count == 0 {
                                     commas.push(f);
                                 }
                             }
-                            if commas.len() == var[0].matches(',').count()
-                            {
+                            if commas.len() == var[0].matches(',').count() {
                                 start = 0;
                                 split = Vec::new();
-                                for end in commas
-                                {
+                                for end in commas {
                                     split.push(&temp[start..end]);
                                     start = end + 1;
                                 }
                                 split.push(&temp[start..]);
                                 value = var[1].clone();
-                                for i in 0..split.len()
-                                {
+                                for i in 0..split.len() {
                                     value = value.replace(
                                         v[v.len()
                                             - 2 * (i as i32 - split.len() as i32).unsigned_abs()
@@ -220,14 +176,11 @@ pub fn input_var(
                                 output.push_str(&input_var(&value, vars, Some(&var[0]), options));
                                 output.push(')');
                             }
-                        }
-                        else
-                        {
+                        } else {
                             not_pushed = false;
                             output.push('(');
                             temp = &chars[j + var[0].split('(').next().unwrap().len() + 1..i + 1];
-                            if temp.ends_with(&[')'])
-                            {
+                            if temp.ends_with(&[')']) {
                                 temp = &temp[..temp.len() - 1];
                             }
                             output.push_str(
@@ -238,21 +191,16 @@ pub fn input_var(
                             );
                             output.push(')');
                         }
-                    }
-                    else
-                    {
+                    } else {
                         i = o;
                     }
-                }
-                else if i + vl <= chars.len()
+                } else if i + vl <= chars.len()
                     && chars[i..i + vl].iter().collect::<String>() == var[0]
                     && push
                     && !is_func(&get_word(&chars[i..]))
                 {
-                    if let Some(n) = dont_do
-                    {
-                        if n == var[0]
-                        {
+                    if let Some(n) = dont_do {
+                        if n == var[0] {
                             return String::new();
                         }
                     }
@@ -264,30 +212,23 @@ pub fn input_var(
                 }
             }
         }
-        if (c != ' ' || (i == 0 || chars[i - 1] != ' ')) && not_pushed
-        {
-            if c.is_alphabetic()
-            {
+        if (c != ' ' || (i == 0 || chars[i - 1] != ' ')) && not_pushed {
+            if c.is_alphabetic() {
                 push = false;
             }
             output.push(c);
         }
         i += 1;
     }
-    if output.is_empty()
-    {
+    if output.is_empty() {
         input.to_string()
-    }
-    else
-    {
+    } else {
         output
     }
 }
-pub fn get_word(word: &[char]) -> String
-{
+pub fn get_word(word: &[char]) -> String {
     let mut pos = 0;
-    for (i, c) in word.iter().enumerate()
-    {
+    for (i, c) in word.iter().enumerate() {
         if !c.is_alphabetic()
             || (*c == 'x' && (i + 1 == word.len() || !word[i + 1].is_alphabetic()))
         {
@@ -297,8 +238,7 @@ pub fn get_word(word: &[char]) -> String
     }
     word[..pos].iter().collect::<String>()
 }
-pub fn get_vars(prec: u32) -> Vec<[String; 2]>
-{
+pub fn get_vars(prec: u32) -> Vec<[String; 2]> {
     let pi = Float::with_val(prec, Pi);
     let tau: Float = pi.clone() * 2;
     let phi: Float = (1 + Float::with_val(prec, 5).sqrt()) / 2;


### PR DESCRIPTION
I simply ran `cargo fmt` over the codebase. I think this would be helpful as it standardizes the codebase formatting both now and an be used in the future.

Perhaps a `rustfmt.toml` can be added?